### PR TITLE
feature #32 : 회원가입 페이지 구현

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -5,6 +5,7 @@
     "react/jsx-props-no-spreading": "off",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }],
     "react-hooks/exhaustive-deps": "off",
+    "react/react-in-jsx-scope": "off",
     "import/prefer-default-export": "off",
     "import/no-unresolved": "off",
     "import/export": "off",

--- a/client/components/signup/SignupModal.tsx
+++ b/client/components/signup/SignupModal.tsx
@@ -1,0 +1,212 @@
+import React, { ChangeEvent, useEffect, useState } from 'react';
+import styled from '@emotion/styled';
+import COLORS from '../../styles/color';
+
+export default function SignupModal() {
+  const [errorMessages, setErrorMessages] = useState({
+    id: '',
+    password: '',
+    password_confirm: '',
+    name: '',
+    email: '',
+    verify: '',
+  });
+  const [formValues, setFormValues] = useState({
+    id: '',
+    password: '',
+    passwordConfirm: '',
+    name: '',
+    email: '',
+    verify: '',
+  });
+
+  const onChangeFields = (e: ChangeEvent) => {
+    const target = e.target as HTMLInputElement;
+    setFormValues({
+      ...formValues,
+      [target.name]: target.value,
+    });
+  };
+
+  useEffect(() => {
+    if (formValues.passwordConfirm === formValues.password)
+      setErrorMessages({ ...errorMessages, password_confirm: '' });
+    else setErrorMessages({ ...errorMessages, password_confirm: '비밀번호가 일치하지 않습니다.' });
+  }, [formValues]);
+
+  return (
+    <ModalWrapper>
+      <ModalHeader>회원가입</ModalHeader>
+      <SignupForm>
+        <SignupRow>
+          <FieldName>아이디: </FieldName>
+          <FieldContent>
+            <MoheyumInputText type="text" name="id" placeholder="아이디" onChange={onChangeFields} />
+          </FieldContent>
+        </SignupRow>
+        {errorMessages.id && <SighupRowMessage>{errorMessages.id}</SighupRowMessage>}
+        <SignupRow>
+          <FieldName>비밀번호: </FieldName>
+          <FieldContent>
+            <MoheyumInputText type="password" name="password" placeholder="비밀번호" onChange={onChangeFields} />
+          </FieldContent>
+        </SignupRow>
+        {errorMessages.password && <SighupRowMessage>{errorMessages.password}</SighupRowMessage>}
+        <SignupRow>
+          <FieldName>비밀번호 확인: </FieldName>
+          <FieldContent>
+            <MoheyumInputText
+              type="password"
+              name="passwordConfirm"
+              placeholder="비밀번호 다시 입력"
+              onChange={onChangeFields}
+            />
+          </FieldContent>
+        </SignupRow>
+        {errorMessages.password_confirm && <SighupRowMessage>{errorMessages.password_confirm}</SighupRowMessage>}
+        <SignupRow>
+          <FieldName>닉네임: </FieldName>
+          <FieldContent>
+            <MoheyumInputText type="text" name="name" placeholder="닉네임" onChange={onChangeFields} />
+          </FieldContent>
+        </SignupRow>
+        {errorMessages.name && <SighupRowMessage>{errorMessages.name}</SighupRowMessage>}
+        <SignupRow>
+          <FieldName>이메일: </FieldName>
+          <FieldContent>
+            <MoheyumInputText type="text" name="email" placeholder="이메일" onChange={onChangeFields} />
+            <MoheyumButton type="button" width={60}>
+              인증
+            </MoheyumButton>
+          </FieldContent>
+        </SignupRow>
+        {errorMessages.email && <SighupRowMessage>{errorMessages.email}</SighupRowMessage>}
+        <SignupRow>
+          <FieldName>&nbsp;</FieldName>
+          <FieldContent>
+            <MoheyumInputText type="text" name="verify" placeholder="인증코드" onChange={onChangeFields} />
+            <MoheyumButton type="button" width={60}>
+              확인
+            </MoheyumButton>
+          </FieldContent>
+        </SignupRow>
+        {errorMessages.verify && <SighupRowMessage>{errorMessages.verify}</SighupRowMessage>}
+      </SignupForm>
+      <SignupSubmitContainer>
+        <MoheyumButton type="button">회원가입</MoheyumButton>
+      </SignupSubmitContainer>
+    </ModalWrapper>
+  );
+}
+
+const ModalHeader = styled.div`
+  width: 100%;
+  font-size: 24px;
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin-top: 50px;
+  margin-bottom: 30px;
+`;
+
+const ModalWrapper = styled.div`
+  width: 488px;
+  /* height: 606px; */
+  background-color: ${COLORS.OFF_WHITE};
+  border: 3px solid ${COLORS.PRIMARY_DARK};
+  border-radius: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const SignupForm = styled.ul`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 0;
+  margin: 0;
+  width: 100%;
+`;
+
+const SignupRow = styled.li`
+  list-style: none;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin: 15px 0;
+`;
+
+const SighupRowMessage = styled.li`
+  margin-top: -2px;
+  margin-bottom: 10px;
+  list-style: none;
+  text-align: center;
+  font-size: 12px;
+  color: ${COLORS.RED};
+  font-weight: 600;
+`;
+
+const FieldName = styled.div`
+  width: 25%;
+  text-align: right;
+  /* margin-right: 7px; */
+`;
+
+const FieldContent = styled.div`
+  width: 60%;
+  display: flex;
+  flex-direction: row;
+  padding: 0px 10px;
+`;
+
+interface sizeProps {
+  width?: number;
+  height?: number;
+}
+
+const MoheyumInputText = styled.input<sizeProps>`
+  box-sizing: border-box;
+  width: ${(props) => (props.width ? `${props.width}px` : '100%')};
+  ${(props) => props.height && `height: ${props.height}px;`}
+  padding: 12px;
+  background-color: ${COLORS.WHITE};
+  border: 2px solid ${COLORS.PRIMARY_DARK};
+  border-radius: 7px;
+  transition: all 0.2s ease;
+  &:focus {
+    outline: 1px solid ${COLORS.PRIMARY_DARK};
+  }
+  &:placeholder-shown {
+    color: ${COLORS.GRAY2};
+  }
+`;
+
+const MoheyumButton = styled.button<sizeProps>`
+  box-sizing: border-box;
+  background-color: ${COLORS.PRIMARY};
+  border-radius: 5px;
+  border: none;
+  color: ${COLORS.WHITE};
+  margin: 0 10px;
+  padding: 10px 0;
+  width: ${(props) => (props.width ? `${props.width}px` : '100%')};
+  ${(props) => props.height && `height: ${props.height}px;`}
+
+  &:hover {
+    background-color: ${COLORS.PRIMARY_DARK};
+  }
+`;
+
+const SignupSubmitContainer = styled.div`
+  width: 85%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 40px 0;
+`;

--- a/client/components/signup/SignupModal.tsx
+++ b/client/components/signup/SignupModal.tsx
@@ -24,6 +24,10 @@ export default function SignupModal() {
   const [verified, setVerified] = useState<boolean>(false);
   const [timer, setTimer] = useState<number>(-1);
 
+  const goBack = () => {
+    console.log('뒤로가잇');
+  };
+
   const onChangeFields = (e: ChangeEvent) => {
     const target = e.target as HTMLInputElement;
     setFormValues({
@@ -138,7 +142,7 @@ export default function SignupModal() {
 
   return (
     <ModalWrapper>
-      <div>뒤로가는버튼을넣을자리</div>
+      <ButtonBack onClick={goBack} />
       <ModalHeader>회원가입</ModalHeader>
       <SignupForm>
         <SignupRow>
@@ -238,7 +242,7 @@ const ModalHeader = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-top: 30px;
+  margin-top: 10px;
   margin-bottom: 30px;
   transition: all 0.3s ease;
 `;
@@ -302,11 +306,12 @@ const MoheyumInputText = styled.input<sizeProps>`
   ${(props) => props.height && `height: ${props.height}px;`}
   padding: 12px;
   background-color: ${COLORS.WHITE};
-  border: 2px solid ${COLORS.PRIMARY_DARK};
+  border: 2px solid ${COLORS.PRIMARY};
   border-radius: 7px;
   transition: all 0.2s ease;
   &:focus {
     outline: 1px solid ${COLORS.PRIMARY_DARK};
+    border: 2px solid ${COLORS.PRIMARY_DARK};
   }
   &:placeholder-shown {
     color: ${COLORS.GRAY2};
@@ -314,12 +319,14 @@ const MoheyumInputText = styled.input<sizeProps>`
   &:disabled {
     background-color: ${COLORS.GRAY3};
     -webkit-box-shadow: 0 0 0 30px ${COLORS.GRAY3} inset !important;
+    box-shadow: 0 0 0 30px ${COLORS.GRAY3} inset !important;
   }
   &:-webkit-autofill,
   &:-webkit-autofill:hover,
   &:-webkit-autofill:focus,
   &:-webkit-autofill:active {
     -webkit-box-shadow: 0 0 0 30px ${COLORS.WHITE} inset;
+    box-shadow: 0 0 0 30px ${COLORS.GRAY3} inset !important;
   }
 `;
 
@@ -345,4 +352,16 @@ const SignupSubmitContainer = styled.div`
   justify-content: center;
   align-items: center;
   margin: 40px 0;
+`;
+
+const ButtonBack = styled.button`
+  border: none;
+  background-color: transparent;
+  align-self: flex-start;
+  width: 15px;
+  height: 15px;
+  margin: 15px 15px;
+  background-image: url('/ico_chveron_left.svg');
+  background-size: contain;
+  background-repeat: no-repeat;
 `;

--- a/client/components/signup/SignupModal.tsx
+++ b/client/components/signup/SignupModal.tsx
@@ -45,6 +45,7 @@ export default function SignupModal() {
     }
     // 인증 메일을 보내는 로직
     setStartVerify(true);
+    setErrorMessages({ ...errorMessages, email: '', verify: '' });
     setTimer(180);
   };
 
@@ -217,6 +218,18 @@ export default function SignupModal() {
   );
 }
 
+const ModalWrapper = styled.div`
+  width: 488px;
+  background-color: ${COLORS.OFF_WHITE};
+  border: 3px solid ${COLORS.PRIMARY_DARK};
+  border-radius: 15px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+`;
+
 const ModalHeader = styled.div`
   width: 100%;
   font-size: 24px;
@@ -228,17 +241,6 @@ const ModalHeader = styled.div`
   margin-top: 30px;
   margin-bottom: 30px;
   transition: all 0.3s ease;
-`;
-
-const ModalWrapper = styled.div`
-  width: 488px;
-  background-color: ${COLORS.OFF_WHITE};
-  border: 3px solid ${COLORS.PRIMARY_DARK};
-  border-radius: 15px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
 `;
 
 const SignupForm = styled.ul`
@@ -311,6 +313,13 @@ const MoheyumInputText = styled.input<sizeProps>`
   }
   &:disabled {
     background-color: ${COLORS.GRAY3};
+    -webkit-box-shadow: 0 0 0 30px ${COLORS.GRAY3} inset !important;
+  }
+  &:-webkit-autofill,
+  &:-webkit-autofill:hover,
+  &:-webkit-autofill:focus,
+  &:-webkit-autofill:active {
+    -webkit-box-shadow: 0 0 0 30px ${COLORS.WHITE} inset;
   }
 `;
 

--- a/client/components/signup/SignupModal.tsx
+++ b/client/components/signup/SignupModal.tsx
@@ -95,6 +95,7 @@ export default function SignupModal() {
 
   const submitSignup = () => {
     if (!validateForm()) return;
+    setErrorMessages({ id: '', password: '', password_confirm: '', name: '', email: '', verify: '' });
     // do Signup
     console.log('회원가입해~!~!');
   };

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import Introduction from '../components/Introduction';
 import router from 'next/router';
-import Login from '../components/Login';
 import styled from '@emotion/styled';
 
 const Frame = styled.div`
@@ -24,6 +22,6 @@ export default function Home() {
     // 닉네임: 1글자 이상 영어 16글자 특수문자 x
     // 아이디: 4글자 16글자 특수문자 x
     // 비밀번호: 8글자 16글자 특수문자 o
-    <Frame></Frame>
+    <Frame />
   );
 }

--- a/client/pages/login.tsx
+++ b/client/pages/login.tsx
@@ -2,5 +2,5 @@ import React from 'react';
 import Introduction from '../components/Introduction';
 
 export default function login() {
-  return <Introduction></Introduction>;
+  return <Introduction />;
 }

--- a/client/pages/signup.tsx
+++ b/client/pages/signup.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import SignupModal from '../components/signup/SignupModal';
+
+export default function Signup() {
+  return <SignupModal />;
+}

--- a/client/public/ico_chveron_left.svg
+++ b/client/public/ico_chveron_left.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7 13L1 7L7 1" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## Description
- #32 
- 실행 후 `http://localhost:3000/signup` 에서 확인할 수 있습니다.
- 피그마의 레이아웃과 약간 다른 점이 있습니다. 뒤로가기 버튼이나, 각 요소들의 크기들 등.. 선민님과는 대략적으로 이야기를 나눴지만 피그마로 했던 디자인을 실제로 구현해놓고 보니 정말 이상해서 위치만 참고하고 융통성있는 재배치가 필요해 보입니다. 정말 안좋은 방법이긴 하지만요..
- **PR을 작성하면서 발견했는데, 피그마에 TextInput에 대한 디자인이 여러 개 존재함을 확인했습니다.**
  - 왜 테두리가 `primary-dark`를 사용하고 있는지 의심하고 있었는데 이런 문제가 있었네요. 디자이너가 없는데 검수해서 뭐하냐 싶었는데 검수를 해야했나 싶기도 하고 그런다고 누가 발견했겠냐 싶기도 한 것이..
- BE 요청을 보내거나 Routing되는 부분은 일단 제외하고 구현했습니다. 로그인 페이지가 구현되면 한 번에 붙이고 이슈 Close 하겠습니다.

## Todos
- `/public` 디렉토리의 이미지들 네이밍 컨벤션을 확정지을 필요가 있습니다.
  - 컴포넌트 tsx 파일을 제외한 모든 파일을 소문자로 하기로 정했던 것 같은데 그 이전에 생성된 아이콘 파일들은 PascalCase로 되어 있습니다. 생각해보니 제가 넣은 아이콘도 snake_case로 되어 있네요.
- Font에 대한 전역 import가 필요합니다.
  - 스타일 관련된 문제가 정립되면(목요일 예상) Noto-sans 폰트를 전역으로 적용할 예정입니다. 지금은 정말 못생겼네요
- 이건 조금 벗어난 이야기인데, UTF-8 기준 한글이 3바이트를 차지한다는 충격적인 사실이 밝혀지면서 우리가 정했던 [회원가입 폼 검증 기준](https://github.com/boostcampwm-2022/web34-moheyum/issues/32#issuecomment-1313779006)에 문제가 생겼습니다. 보완이 필요해욨 
---
커밋 컨벤션을 마구 어겼네요. 유의하도록 하겠습니다..