### PR TITLE
Feature/be/62 profile avatar upload

### DIFF
--- a/server/src/common/database/user.repository.ts
+++ b/server/src/common/database/user.repository.ts
@@ -38,12 +38,12 @@ export class UserRepository {
 
   async findOneAndUpdate(
     userFilterQuery: FilterQuery<User>,
-    userUpdateDto: UserUpdateDto,
+    user: Partial<User>,
   ) {
     const result = this.userModel.findOneAndUpdate(
       userFilterQuery,
       {
-        $set: userUpdateDto,
+        $set: user,
       },
       { new: true },
     );

--- a/server/src/user/dto/user-Update-dto.ts
+++ b/server/src/user/dto/user-Update-dto.ts
@@ -10,10 +10,6 @@ import {
 export class UserUpdateDto {
   @IsString()
   @IsOptional()
-  profileimg: string;
-
-  @IsString()
-  @IsOptional()
   @MaxLength(500)
   bio: string;
 

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -6,15 +6,20 @@ import {
   Put,
   HttpCode,
   UseGuards,
+  Post,
+  UploadedFile,
+  UseInterceptors,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserUpdateDto } from './dto/user-Update-dto';
 import { UpdateAuthGuard } from 'src/common/guard/update-user.guard';
 import { JwtAuthGuard } from 'src/common/guard/jwt-auth.guard';
+import { NcloudService } from 'src/ncloud/ncloud.service';
+import { FileInterceptor } from '@nestjs/platform-express';
 
 @Controller('user')
 export class UserController {
-  constructor(private userService: UserService) {}
+  constructor(private userService: UserService, private ncloudServie: NcloudService) {}
   @Get('/:userid')
   async getUserProfile(@Param('userid') userid: string) {
     return {
@@ -34,5 +39,19 @@ export class UserController {
       message: 'success',
       data: await this.userService.updateUserProfile(userid, userUpdateDto),
     };
+  }
+
+  @UseGuards(JwtAuthGuard, UpdateAuthGuard)
+  @UseInterceptors(FileInterceptor('file'))
+  @Post('/:userid/avatar')
+  async uploadAvatar(@Param('userid') userid: string, @UploadedFile() file: Express.Multer.File) {
+    const url = await this.ncloudServie.upload(file);
+    await this.userService.updateUserAvatar(userid, url.imageLink);
+    return {
+      message: 'success',
+      data: {
+        profileimg: url.imageLink
+      }
+    }
   }
 }

--- a/server/src/user/user.controller.ts
+++ b/server/src/user/user.controller.ts
@@ -40,10 +40,11 @@ export class UserController {
       data: await this.userService.updateUserProfile(userid, userUpdateDto),
     };
   }
-
+  
+  @HttpCode(200)
   @UseGuards(JwtAuthGuard, UpdateAuthGuard)
   @UseInterceptors(FileInterceptor('file'))
-  @Post('/:userid/avatar')
+  @Put('/:userid/avatar')
   async uploadAvatar(@Param('userid') userid: string, @UploadedFile() file: Express.Multer.File) {
     const url = await this.ncloudServie.upload(file);
     await this.userService.updateUserAvatar(userid, url.imageLink);

--- a/server/src/user/user.module.ts
+++ b/server/src/user/user.module.ts
@@ -5,6 +5,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { User, UserSchema } from '../common/database/user.schema';
 import { UserRepository } from 'src/common/database/user.repository';
 import { DatabaseModule } from 'src/common/database/database.module';
+import { NcloudService } from 'src/ncloud/ncloud.service';
 
 @Module({
   imports: [
@@ -12,6 +13,6 @@ import { DatabaseModule } from 'src/common/database/database.module';
     DatabaseModule,
   ],
   controllers: [UserController],
-  providers: [UserService, UserRepository],
+  providers: [UserService, UserRepository, NcloudService],
 })
 export class UserModule {}

--- a/server/src/user/user.service.ts
+++ b/server/src/user/user.service.ts
@@ -31,4 +31,12 @@ export class UserService {
       profileImg: data.profileimg,
     });
   }
+
+  updateUserAvatar(userid: string, url: string) {
+    return this.userRepository.findOneAndUpdate(
+      {userid},
+      {profileimg: url}
+    )
+    
+  }
 }


### PR DESCRIPTION
유저 프로필 업데이트에서 bio, nickname과 avatar profileimg 를 분리했습니다.

아바타 업로드를 위한 주소는 `/api/user/:userid/avatar` 입니다.

응답은 아래와 같습니다.

```json
{
  "message": "success",
  "data": {
    "profileimg": "https://kr.object.ncloudstorage.com/boostcamp-webe34-dev/2e803e323f9d7c290535a523f0a70511bdcb014b0f24e7d6ce845a226807a7b7c41090e80fac2c23164027d67a2fb931a83cce091f38c46455cb08a57262a82b.png"
  }
}
```

자세한 내용은 API 스펙을 참고해주세요.