### PR TITLE
Feature/fe/76 sidebar image

### DIFF
--- a/client/components/Notification/index.tsx
+++ b/client/components/Notification/index.tsx
@@ -43,12 +43,11 @@ export default function Notification() {
                 url={item.url}
                 message={item.message}
                 createdAt={item.createdAt}
+                key={item._id}
                 ref={lastNotificationElementRef}
               />
             );
-          return (
-            <NotificationCard url={item.url} message={item.message} createdAt={item.createdAt} />
-          );
+          return <NotificationCard url={item.url} message={item.message} createdAt={item.createdAt} key={item._id} />;
         })}
         {loading && <ExceptionPage>Loading</ExceptionPage>}
         {error && <ExceptionPage>error</ExceptionPage>}

--- a/client/components/ProfileEdit/index.tsx
+++ b/client/components/ProfileEdit/index.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/legacy/image';
 import Router from 'next/router';
 import React, { ChangeEvent, RefObject, useEffect, useRef, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { useForm } from 'react-hook-form';
 import * as yup from 'yup';
 import { yupResolver } from '@hookform/resolvers';
@@ -65,6 +65,8 @@ export default function ProfileEditSection() {
   };
 
   const authedUserInfo = useRecoilValue(authedUser);
+  const setAuthedUserInfo = useSetRecoilState(authedUser);
+
   const [myProfile, setMyProfile] = useState<Profile>({
     userid: authedUserInfo.userid,
     email: '',
@@ -113,11 +115,19 @@ export default function ProfileEditSection() {
       credentials: 'include',
       body: formData,
     })
+      .then(async (e) => {
+        const res = await e.json();
+        const url = res.data.profileimg;
+        // profileImg수정
+        setAuthedUserInfo((userInfo) => {
+          const profileimg = url;
+          return { ...userInfo, profileimg };
+        });
+      })
       .catch((e) => {
         alert(e);
         console.error(e);
-      })
-      .finally(() => {});
+      });
   };
 
   const handleProfileSubmit = () => {

--- a/client/components/ProfileEdit/index.tsx
+++ b/client/components/ProfileEdit/index.tsx
@@ -108,6 +108,7 @@ export default function ProfileEditSection() {
 
   const handleProfileImgSubmit = async () => {
     // fetch('/api/user/')
+    if (!profileImg) return;
     const formData = new FormData();
     formData.append('file', profileImg!);
     fetch(`/api/user/${myProfile.userid}/avatar`, {
@@ -123,6 +124,7 @@ export default function ProfileEditSection() {
           const profileimg = url;
           return { ...userInfo, profileimg };
         });
+        setProfileImg(undefined);
       })
       .catch((e) => {
         alert(e);


### PR DESCRIPTION
- 프로필 편집시 사이드바의 이미지가 즉시 변경 안되는 오류 수정
- 알림 페이지 key값 추가
- 이미지 변경 없을시 프로필 편집 버튼 누르면 아무 반응 없게 추가(오류 메시지 안뜨게 작업)
- 동일 이미지로 프로필 사진 변경 버튼 누를시 계속해서 api를 요청하는 오류 수정