### PR TITLE
Feature/fe/124 검색 페이지 구현

### DIFF
--- a/client/components/Follow/Follower.tsx
+++ b/client/components/Follow/Follower.tsx
@@ -42,11 +42,9 @@ export default function FollowerSection({ userData }: { userData: Props }) {
     <Wrapper>
       <TopBar>
         <div>
-          <div>
-            <ButtonBack type="button" onClick={goBack} />
-          </div>
-          <h1>{userData.nickname || '유저 닉네임'}</h1>
+          <ButtonBack type="button" onClick={goBack} />
         </div>
+        <h1>{userData.nickname || '유저 닉네임'}</h1>
       </TopBar>
       <TopFollowContainer>
         <TopFollowActivated>

--- a/client/components/Follow/Following.tsx
+++ b/client/components/Follow/Following.tsx
@@ -43,11 +43,9 @@ export default function FollowingSection({ userData }: { userData: Props }) {
     <Wrapper>
       <TopBar>
         <div>
-          <div>
-            <ButtonBack type="button" onClick={goBack} />
-          </div>
-          <h1>{userData.nickname || '유저 닉네임'}</h1>
+          <ButtonBack type="button" onClick={goBack} />
         </div>
+        <h1>{userData.nickname || '유저 닉네임'}</h1>
       </TopBar>
       <TopFollowContainer>
         <TopFollowDeactivated>

--- a/client/components/Main/Mainsection/index.style.ts
+++ b/client/components/Main/Mainsection/index.style.ts
@@ -47,4 +47,5 @@ export const ArticlesSection = styled.div`
 
 export const Newsfeed = styled.div`
   overflow-y: scroll;
+  flex: 1;
 `;

--- a/client/components/Notification/index.tsx
+++ b/client/components/Notification/index.tsx
@@ -28,12 +28,8 @@ export default function Notification() {
   return (
     <Wrapper>
       <TopBar>
-        <div>
-          <div>
-            <ButtonBack type="button" onClick={goBack} />
-          </div>
-          <h1>알림</h1>
-        </div>
+        <ButtonBack type="button" onClick={goBack} />
+        <h1>알림</h1>
       </TopBar>
       <NotificationContainer>
         {pages.map((item: any, index: number) => {

--- a/client/components/ProfileEdit/index.tsx
+++ b/client/components/ProfileEdit/index.tsx
@@ -159,11 +159,9 @@ export default function ProfileEditSection() {
     <Wrapper>
       <TopBar>
         <div>
-          <div>
-            <ButtonBack type="button" onClick={goBack} />
-          </div>
-          <h1>프로필 편집</h1>
+          <ButtonBack type="button" onClick={goBack} />
         </div>
+        <h1>프로필 편집</h1>
       </TopBar>
       <div>
         <form onSubmit={handleSubmit(handleProfileImgSubmit)} style={{ width: '500px' }} encType="multipart/form-data">

--- a/client/components/ReadParentPost/index.tsx
+++ b/client/components/ReadParentPost/index.tsx
@@ -25,11 +25,9 @@ export default function ReadPost({ postData }: Props) {
     <Wrapper>
       <TopBar>
         <div>
-          <div>
-            <ButtonBack type="button" onClick={goBack} />
-          </div>
-          <h1>답글 작성</h1>
+          <ButtonBack type="button" onClick={goBack} />
         </div>
+        <h1>답글 작성</h1>
       </TopBar>
       <ContentBox>
         <HeaderBox>

--- a/client/components/ReadPost/index.style.ts
+++ b/client/components/ReadPost/index.style.ts
@@ -17,6 +17,7 @@ export const PostContent = styled.div`
   overflow-x: hidden;
   overflow-y: scroll;
   display: flex;
+  flex: 1;
   flex-direction: column;
   align-items: center;
   -ms-overflow-style: none;

--- a/client/components/ReadPost/index.tsx
+++ b/client/components/ReadPost/index.tsx
@@ -63,11 +63,9 @@ export default function ReadPost({ postData, title }: PostData) {
     <Wrapper>
       <TopBar>
         <div>
-          <div>
-            <ButtonBack type="button" onClick={goBack} />
-          </div>
-          <h1>{title}</h1>
+          <ButtonBack type="button" onClick={goBack} />
         </div>
+        <h1>{title}</h1>
       </TopBar>
       <PostContent>
         {postData.parentPost ? <ParentPost post={postData.parent.at(0) as Parent} /> : <div />}

--- a/client/components/Search/PostResult/index.tsx
+++ b/client/components/Search/PostResult/index.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function PostResult() {
+  return <div />;
+}

--- a/client/components/Search/PostResult/index.tsx
+++ b/client/components/Search/PostResult/index.tsx
@@ -1,5 +1,100 @@
-import React from 'react';
+import styled from '@emotion/styled';
+import React, { useCallback, useRef, useState } from 'react';
+import COLORS from '../../../styles/color';
+import Paginator, { NEXT } from '../../../utils/paginator';
+import { ArticleCard } from '../../Main/Articlecard';
 
-export default function PostResult() {
-  return <div />;
+export default function PostResult({ keyword }: { keyword: string }) {
+  const [nextCursor, setNextCursor] = useState('START');
+  const { loading, error, pages, next } = Paginator(`/api/post/search?keyword=${keyword}`, nextCursor);
+
+  const observer = useRef<any>();
+  const lastFollowElementRef = useCallback(
+    (node: any) => {
+      if (loading) return;
+      if (observer.current) observer.current.disconnect();
+      observer.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && next !== NEXT.END) {
+          setNextCursor(next);
+        }
+      });
+      if (node) observer.current.observe(node);
+    },
+    [loading, next !== NEXT.END]
+  );
+
+  return (
+    <ResultContainer>
+      <ResultHeader>
+        <span>{keyword}</span>에 대한 게시물 검색 결과
+      </ResultHeader>
+      {pages.map((item: any, index: number) => {
+        if (pages.length === index + 1)
+          return (
+            <ArticleCard
+              author={item.authorDetail.userid}
+              profileimg={item.authorDetail.profileimg}
+              id={item._id}
+              description={item.description}
+              date={item.createdAt}
+              comments={item.childPosts}
+              nickname={item.authorDetail.nickname}
+              key={item._id}
+              ref={lastFollowElementRef}
+            />
+          );
+        return (
+          <ArticleCard
+            author={item.authorDetail.userid}
+            profileimg={item.authorDetail.profileimg}
+            id={item._id}
+            description={item.description}
+            date={item.createdAt}
+            comments={item.childPosts}
+            nickname={item.authorDetail.nickname}
+            key={item._id}
+          />
+        );
+      })}
+      {!loading && pages.length === 0 && <EmptyMessage>검색 결과 없음</EmptyMessage>}
+      {loading && <ErrorMessage>Loading</ErrorMessage>}
+      {error && <ErrorMessage>error</ErrorMessage>}
+    </ResultContainer>
+  );
 }
+
+export const ResultContainer = styled.div`
+  width: 100%;
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 15px;
+`;
+
+export const ResultHeader = styled.h1`
+  width: 100%;
+  font-size: 24px;
+  padding: 15px;
+  border-bottom: 2px solid ${COLORS.GRAY4};
+  margin-bottom: 30px;
+  & > span {
+    font-weight: 700;
+    font-size: 28px;
+  }
+`;
+
+export const ErrorMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;
+
+export const EmptyMessage = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  color: ${COLORS.GRAY3};
+`;

--- a/client/components/Search/UserResult/index.tsx
+++ b/client/components/Search/UserResult/index.tsx
@@ -2,11 +2,11 @@ import styled from '@emotion/styled';
 import React, { useCallback, useRef, useState } from 'react';
 import COLORS from '../../../styles/color';
 import Paginator, { NEXT } from '../../../utils/paginator';
-import { ArticleCard } from '../../Main/Articlecard';
+import { FollowMember } from '../../Follow/FollowMember';
 
-export default function PostResult({ keyword }: { keyword: string }) {
+export default function UserResult({ keyword }: { keyword: string }) {
   const [nextCursor, setNextCursor] = useState('START');
-  const { loading, error, pages, next } = Paginator(`/api/post/search?keyword=${keyword}`, nextCursor);
+  const { loading, error, pages, next } = Paginator(`/api/user/search?keyword=${keyword}`, nextCursor);
 
   const observer = useRef<any>();
   const lastFollowElementRef = useCallback(
@@ -28,27 +28,21 @@ export default function PostResult({ keyword }: { keyword: string }) {
       {pages.map((item: any, index: number) => {
         if (pages.length === index + 1)
           return (
-            <ArticleCard
-              author={item.authorDetail.userid}
-              profileimg={item.authorDetail.profileimg}
-              id={item._id}
-              description={item.description}
-              date={item.createdAt}
-              comments={item.childPosts}
-              nickname={item.authorDetail.nickname}
+            <FollowMember
+              userid={item.userid}
+              nickname={item.nickname}
+              profileimg={item.profileimg}
+              displayButton
               key={item._id}
               ref={lastFollowElementRef}
             />
           );
         return (
-          <ArticleCard
-            author={item.authorDetail.userid}
-            profileimg={item.authorDetail.profileimg}
-            id={item._id}
-            description={item.description}
-            date={item.createdAt}
-            comments={item.childPosts}
-            nickname={item.authorDetail.nickname}
+          <FollowMember
+            userid={item.userid}
+            nickname={item.nickname}
+            profileimg={item.profileimg}
+            displayButton
             key={item._id}
           />
         );

--- a/client/components/Search/index.tsx
+++ b/client/components/Search/index.tsx
@@ -25,11 +25,17 @@ export default function SearchSection() {
   };
 
   useEffect(() => {
+    if (!inputRef.current) return;
     if (initKeyword) {
-      if (Array.isArray(initKeyword)) setKeyword(initKeyword[0]);
-      else setKeyword(initKeyword);
+      if (Array.isArray(initKeyword)) {
+        setKeyword(initKeyword[0]);
+        [inputRef.current.value] = initKeyword;
+      } else {
+        setKeyword(initKeyword);
+        inputRef.current.value = initKeyword;
+      }
     }
-  }, []);
+  }, [inputRef.current]);
 
   const changeTab = (idx: number) => {
     setTabIndex(idx);

--- a/client/components/Search/index.tsx
+++ b/client/components/Search/index.tsx
@@ -1,0 +1,96 @@
+import styled from '@emotion/styled';
+import Image from 'next/image';
+import { useRouter } from 'next/router';
+import React, { KeyboardEvent, useEffect, useState } from 'react';
+import COLORS from '../../styles/color';
+import { TopBar } from '../../styles/common';
+import { mainSectionStyle } from '../../styles/mixin';
+
+export default function SearchSection() {
+  const router = useRouter();
+  const initKeyword = router.query.keyword;
+  const [keyword, setKeyword] = useState('');
+  //   const [userResult, setUserResult] = useState();
+  //   const [postResult, setPostResult] = useState();
+
+  const handleEnter = (e: KeyboardEvent<HTMLInputElement>) => {
+    const { key } = e;
+    if (key === 'Enter') {
+      e.preventDefault();
+      // to search
+      doSearch();
+    }
+  };
+
+  useEffect(() => {
+    if (initKeyword) {
+      if (Array.isArray(initKeyword)) setKeyword(initKeyword[0]);
+      else setKeyword(initKeyword);
+      doSearch();
+    }
+  }, []);
+
+  const doSearch = () => {
+    console.log(`searching ${keyword}`);
+  };
+
+  return (
+    <Wrapper>
+      <TopBar>
+        <TopBarContainer>
+          <SearchInputBar
+            type="text"
+            placeholder="검색어를 입력하세요."
+            value={keyword}
+            onInput={(e) => setKeyword(e.currentTarget.value)}
+            onKeyDown={handleEnter}
+          />
+          <Image alt="search button" width={30} height={30} src="/search.svg" />
+        </TopBarContainer>
+      </TopBar>
+      <div>내용</div>
+    </Wrapper>
+  );
+}
+
+export const Wrapper = styled.div`
+  ${mainSectionStyle}
+  @media only screen and (max-width: ${({ theme }) => theme.wideWindow}) {
+    width: calc(100% - ${({ theme }) => theme.sidebar.maxWidth});
+  }
+  @media only screen and (max-width: ${({ theme }) => theme.smallWindow}) {
+    width: calc(100% - ${({ theme }) => theme.sidebar.minWidth});
+  }
+`;
+
+export const TopBarContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  & > img {
+    user-select: none;
+    cursor: pointer;
+    margin-right: 30px;
+  }
+`;
+
+export const SearchInputBar = styled.input`
+  border: none;
+  height: 100%;
+  flex: 1;
+  padding: 5px 30px;
+  font-size: 20px;
+  color: ${COLORS.BLACK};
+  font-weight: 500;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:placeholder-shown {
+    color: ${COLORS.GRAY3};
+  }
+`;

--- a/client/components/Search/index.tsx
+++ b/client/components/Search/index.tsx
@@ -1,24 +1,24 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import React, { KeyboardEvent, useEffect, useState } from 'react';
+import React, { KeyboardEvent, useEffect, useRef, useState } from 'react';
 import COLORS from '../../styles/color';
 import { TopBar } from '../../styles/common';
 import { mainSectionStyle } from '../../styles/mixin';
+import PostResult from './PostResult';
 
 export default function SearchSection() {
   const router = useRouter();
   const initKeyword = router.query.keyword;
   const [keyword, setKeyword] = useState('');
-  //   const [userResult, setUserResult] = useState();
-  //   const [postResult, setPostResult] = useState();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const handleEnter = (e: KeyboardEvent<HTMLInputElement>) => {
     const { key } = e;
     if (key === 'Enter') {
       e.preventDefault();
-      // to search
-      doSearch();
+      if (!inputRef.current) return;
+      setKeyword(inputRef.current.value);
     }
   };
 
@@ -26,29 +26,18 @@ export default function SearchSection() {
     if (initKeyword) {
       if (Array.isArray(initKeyword)) setKeyword(initKeyword[0]);
       else setKeyword(initKeyword);
-      doSearch();
     }
   }, []);
-
-  const doSearch = () => {
-    console.log(`searching ${keyword}`);
-  };
 
   return (
     <Wrapper>
       <TopBar>
         <TopBarContainer>
-          <SearchInputBar
-            type="text"
-            placeholder="검색어를 입력하세요."
-            value={keyword}
-            onInput={(e) => setKeyword(e.currentTarget.value)}
-            onKeyDown={handleEnter}
-          />
+          <SearchInputBar type="text" placeholder="검색어를 입력하세요." onKeyDown={handleEnter} ref={inputRef} />
           <Image alt="search button" width={30} height={30} src="/search.svg" />
         </TopBarContainer>
       </TopBar>
-      <div>내용</div>
+      <PostResult keyword={keyword} />
     </Wrapper>
   );
 }

--- a/client/components/Search/index.tsx
+++ b/client/components/Search/index.tsx
@@ -6,12 +6,14 @@ import COLORS from '../../styles/color';
 import { TopBar } from '../../styles/common';
 import { mainSectionStyle } from '../../styles/mixin';
 import PostResult from './PostResult';
+import UserResult from './UserResult';
 
 export default function SearchSection() {
   const router = useRouter();
   const initKeyword = router.query.keyword;
   const [keyword, setKeyword] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
+  const [tabIndex, setTabIndex] = useState(0); // 0 게시글, 1 사용자
 
   const handleEnter = (e: KeyboardEvent<HTMLInputElement>) => {
     const { key } = e;
@@ -29,15 +31,28 @@ export default function SearchSection() {
     }
   }, []);
 
+  const changeTab = (idx: number) => {
+    setTabIndex(idx);
+  };
+
   return (
     <Wrapper>
       <TopBar>
         <TopBarContainer>
-          <SearchInputBar type="text" placeholder="검색어를 입력하세요." onKeyDown={handleEnter} ref={inputRef} />
           <Image alt="search button" width={30} height={30} src="/search.svg" />
+          <SearchInputBar type="text" placeholder="검색어를 입력하세요." onKeyDown={handleEnter} ref={inputRef} />
         </TopBarContainer>
       </TopBar>
-      <PostResult keyword={keyword} />
+      <TabContainer>
+        <button type="button" className={tabIndex === 0 ? 'selected' : ''} onClick={() => changeTab(0)}>
+          게시글 검색
+        </button>
+        <button type="button" className={tabIndex === 1 ? 'selected' : ''} onClick={() => changeTab(1)}>
+          사용자 검색
+        </button>
+      </TabContainer>
+      {tabIndex === 0 && <PostResult keyword={keyword} />}
+      {tabIndex === 1 && <UserResult keyword={keyword} />}
     </Wrapper>
   );
 }
@@ -62,7 +77,7 @@ export const TopBarContainer = styled.div`
   & > img {
     user-select: none;
     cursor: pointer;
-    margin-right: 30px;
+    margin-left: 20px;
   }
 `;
 
@@ -70,7 +85,7 @@ export const SearchInputBar = styled.input`
   border: none;
   height: 100%;
   flex: 1;
-  padding: 5px 30px;
+  padding: 10px;
   font-size: 20px;
   color: ${COLORS.BLACK};
   font-weight: 500;
@@ -80,6 +95,33 @@ export const SearchInputBar = styled.input`
   }
 
   &:placeholder-shown {
-    color: ${COLORS.GRAY3};
+    color: ${COLORS.GRAY4};
+  }
+`;
+
+export const TabContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  & > button {
+    flex: 1;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    padding: 10px;
+    background-color: ${COLORS.PRIMARY};
+    color: ${COLORS.WHITE};
+    font-size: 18px;
+    border: none;
+
+    &.selected {
+      background-color: ${COLORS.WHITE};
+      color: ${COLORS.BLACK};
+      font-weight: 700;
+    }
   }
 `;

--- a/client/components/Write/Editor/index.style.ts
+++ b/client/components/Write/Editor/index.style.ts
@@ -4,6 +4,7 @@ import { buttonStyle, displayColumn, markdownStyle } from '../../../styles/mixin
 
 export const Wrapper = styled.div`
   height: 100%;
+  flex: 1;
   background-color: white;
   display: flex;
   flex-direction: column;
@@ -106,7 +107,6 @@ export const PreviewTextBox = styled.div`
 `;
 
 export const CommentTopBar = styled.div`
-  border-top: 2px solid #d7d7d7;
   background-color: ${COLORS.WHITE};
   height: 70px;
   width: 100%;

--- a/client/components/Write/index.tsx
+++ b/client/components/Write/index.tsx
@@ -19,11 +19,9 @@ export default function EditorWrapper({ postData }: Props) {
       {postData._id === '' && (
         <TopBar>
           <div>
-            <div>
-              <ButtonBack type="button" onClick={goBack} />
-            </div>
-            <h1>새 글 작성</h1>
+            <ButtonBack type="button" onClick={goBack} />
           </div>
+          <h1>새 글 작성</h1>
         </TopBar>
       )}
       <Editor postData={postData} />

--- a/client/pages/search.tsx
+++ b/client/pages/search.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import Frame from '../styles/frame';
-import MainSection from '../components/Main/Mainsection';
 import SideBar from '../components/Main/SideBar';
 import AuthGuard from '../components/AuthGuard';
+import SearchSection from '../components/Search';
 
 export default function search() {
   return (
     <AuthGuard noRedirect>
       <Frame>
         <SideBar />
-        <MainSection />
+        <SearchSection />
       </Frame>
     </AuthGuard>
   );

--- a/client/styles/common.ts
+++ b/client/styles/common.ts
@@ -4,7 +4,7 @@ import { displayColumn } from './mixin';
 import { mainSectionSize } from './theme';
 
 export const MainTopBar = styled.header`
-  position: fixed;
+  /* position: fixed; */
   background-color: ${COLORS.WHITE};
   height: 61px;
   border-bottom: 2px solid ${COLORS.GRAY3};
@@ -20,7 +20,7 @@ export const MainTopBar = styled.header`
 `;
 
 export const TopBar = styled.header`
-  position: fixed;
+  /* position: fixed; */
   background-color: ${COLORS.WHITE};
   height: 61px;
   width: ${mainSectionSize}px;

--- a/client/styles/common.ts
+++ b/client/styles/common.ts
@@ -25,22 +25,17 @@ export const TopBar = styled.header`
   height: 61px;
   width: ${mainSectionSize}px;
   border-bottom: 2px solid ${COLORS.GRAY3};
-  ${displayColumn}
-  div {
-    display: flex;
-    height: 12px;
-    h1 {
-      flex: 1;
-      font-size: 22px;
-      font-weight: 500;
-      text-align: left;
-      color: ${COLORS.BLACK};
-      margin-left: 6px;
-      ${displayColumn}
-    }
-    div {
-      height: 12px;
-    }
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  h1 {
+    flex: 1;
+    font-size: 22px;
+    font-weight: 500;
+    text-align: left;
+    color: ${COLORS.BLACK};
+    margin-left: 6px;
+    ${displayColumn}
   }
 `;
 
@@ -52,5 +47,6 @@ export const ButtonBack = styled.button`
   margin-left: 15px;
   background-image: url('/ico_chveron_left.svg');
   background-repeat: no-repeat;
+  background-size: contain;
   cursor: pointer;
 `;

--- a/client/styles/mixin.ts
+++ b/client/styles/mixin.ts
@@ -9,9 +9,9 @@ export const mainSectionStyle = css`
   display: flex;
   flex-direction: column;
   background-color: ${COLORS.WHITE};
-  & > div {
+  /* & > div {
     margin-top: 61px;
-  }
+  } */
 `;
 
 export const displayCenter = css`

--- a/client/utils/paginator.ts
+++ b/client/utils/paginator.ts
@@ -24,7 +24,7 @@ export default function Paginator(fetchUrl: string, nextCursor: string) {
     setLoading(true);
     setError(false);
     let fetchUrlwithNext = fetchUrl;
-    if (next !== NEXT.START && next !== NEXT.END) {
+    if (next !== NEXT.START && next !== NEXT.END && nextCursor !== 'START') {
       if (fetchUrlwithNext.includes('?')) fetchUrlwithNext += `&next=${next}`;
       else fetchUrlwithNext += `?next=${next}`;
     }

--- a/client/utils/paginator.ts
+++ b/client/utils/paginator.ts
@@ -24,7 +24,10 @@ export default function Paginator(fetchUrl: string, nextCursor: string) {
     setLoading(true);
     setError(false);
     let fetchUrlwithNext = fetchUrl;
-    if (next !== NEXT.START && next !== NEXT.END) fetchUrlwithNext += `?next=${next}`;
+    if (next !== NEXT.START && next !== NEXT.END) {
+      if (fetchUrlwithNext.includes('?')) fetchUrlwithNext += `&next=${next}`;
+      else fetchUrlwithNext += `?next=${next}`;
+    }
     fetch(`${fetchUrlwithNext}`, {
       signal: abortController.signal,
       method: 'GET',


### PR DESCRIPTION
아래 이슈에 대한 작업 내용입니다.
- https://github.com/boostcampwm-2022/web34-moheyum/issues/124
- https://github.com/boostcampwm-2022/web34-moheyum/issues/125
- https://github.com/boostcampwm-2022/web34-moheyum/issues/127
  
## 참고 사항
- 백엔드  API 호출 수 최적화가 필요할 것 같읍니다.. 키워드가 비어있는 경우 검색을 하면 안되는데 기본적으로 페이지가 렌더링되면 검색을 시작합니다.  
- search에서 받는 comments가 숫자가 아닌 배열입니다. dev 브랜치에 수정이 되었는지 확인이 필요합니다.
- `/search?keyword={keyword}`로 즉시 검색이 가능합니다.
- `TopBar` 관련 css 대거 수정이 포함되어 있습니다.
  - 모든 페이지의 `TopBar`가 이제 `fixed` position을 갖지 않습니다. 페이지 전체가 아닌 `MainSection`만이 스크롤되기 때문에 필요가 없다고 생각합니다.
  - 이 과정에서 `mixin` style의 불필요한 margin을 제거하여 범용성을 개선할 수 있다고 생각합니다.
  - 대부분의 `TopBar` 컴포넌트가 불필요하게 많은 `div`를 사용하는 부분을 보완하였습니다.
- 검색 결과 부분은 `ArticleCard`와 `FollowMember` 컴포넌트를 재사용하였습니다. 어차피 둘 다 레이아웃 수정이 있을거라 당장 이 부분이 못생긴 건 무시하기로 했습니다.
- `paginator`에 일부 코드 수정이 있습니다.
  - 요청 URL에 query string이 사용되는 경우 쿼리에 `next`를 붙이는 과정에 오류가 생깁니다. 그래서 query string이 포함된 URL에 대한 예외처리를 추가하였습니다.
  - `fetchUrl`이 변경된 경우에 대해 `next`가 제대로 clear되지 않습니다. `nextCursor`가 START로 초기화된 경우에 대한 조건을 추가하였습니다. 간단하게 말하면 아래 케이스에서의 오류 해결을 위한 수정입니다.
    - `김치`를 검색 후 `마라탕`으로 검색할 경우 요청 URL에 `김치` 검색에 대한 `next`값이 포함됨
- post search에 대해 pagination이 제대로 작동하지 않는 상황에서 테스트했습니다. dev 브랜치 기준 성익님이 이미 해결하신 이슈입니다.

## 실행 화면
![image](https://user-images.githubusercontent.com/46566891/204989335-00a07a3e-a5f4-494f-8f06-ab527cc256af.png)  
![image](https://user-images.githubusercontent.com/46566891/204989379-1d549157-d337-4cdc-8dd6-9351f743f2c6.png)  
![image](https://user-images.githubusercontent.com/46566891/204989396-dc747495-b299-4660-98d1-72dc8a815752.png)  