### PR TITLE
Refactor/fe/172 redesign components

### DIFF
--- a/client/components/Follow/Follower.tsx
+++ b/client/components/Follow/Follower.tsx
@@ -16,7 +16,7 @@ import type { Props } from '../../pages/[userid]/following';
 
 export default function FollowerSection({ userData }: { userData: Props }) {
   const goBack = () => {
-    Router.back();
+    Router.push(`/${userData.userid}`);
   };
 
   const [nextCursor, setNextCursor] = useState('START');

--- a/client/components/Follow/Following.tsx
+++ b/client/components/Follow/Following.tsx
@@ -17,7 +17,7 @@ import type { Props } from '../../pages/[userid]/following';
 
 export default function FollowingSection({ userData }: { userData: Props }) {
   const goBack = () => {
-    Router.back();
+    Router.push(`/${userData.userid}`);
   };
 
   const [nextCursor, setNextCursor] = useState('START');

--- a/client/components/Main/Articlecard/UserProfile/index.style.ts
+++ b/client/components/Main/Articlecard/UserProfile/index.style.ts
@@ -26,9 +26,8 @@ export const Profile = styled.div`
   height: 50px;
   border-radius: 50px;
   border: 2px solid ${COLORS.PRIMARY};
-  /* margin: 15px; */
+  margin: 5px;
   padding-right: 45px;
-  margin: 15px 15px 15px 0px;
   img {
     width: 50px;
     height: 50px;
@@ -36,12 +35,13 @@ export const Profile = styled.div`
   }
 `;
 export const AuthorDetail = styled.div`
-  #name {
+  margin-left: 5px;
+  .name {
     white-space: nowrap;
     font-weight: 500;
     font-size: 18px;
   }
-  #user-id {
+  .user-id {
     white-space: nowrap;
     margin: 3px 1px;
     color: ${COLORS.GRAY1};

--- a/client/components/Main/Articlecard/UserProfile/index.tsx
+++ b/client/components/Main/Articlecard/UserProfile/index.tsx
@@ -22,8 +22,8 @@ export default function UserProfile({
       </Profile>
       {/* <ProfileImg imgUrl={profileimg} /> */}
       <AuthorDetail>
-        <div id="name">{nickname || '작성자 이름'}</div>
-        <div id="user-id">@{author || '작성자 아이디'}</div>
+        <div className="name">{nickname || '작성자 이름'}</div>
+        <div className="user-id">@{author || '작성자 아이디'}</div>
       </AuthorDetail>
     </Author>
   );

--- a/client/components/Main/Articlecard/index.style.ts
+++ b/client/components/Main/Articlecard/index.style.ts
@@ -3,23 +3,25 @@ import COLORS from '../../../styles/color';
 
 export const Wrapper = styled.div`
   width: inherit;
-  margin: 10px 20px;
   background-color: ${COLORS.WHITE};
-  border-radius: 10px;
-  border: 2px solid ${COLORS.GRAY3};
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  padding: 13px 20px;
+  padding: 0px 36px;
   cursor: pointer;
+
+  &:hover {
+    filter: brightness(0.95);
+  }
 
   & > hr {
     width: 100%;
-    margin: 20px 0;
-    background-color: ${COLORS.GRAY4};
+    margin-top: 16px;
+    background-color: ${COLORS.GRAY3};
     height: 1px;
     border: none;
+    margin-block-end: 0;
   }
 `;
 
@@ -28,9 +30,9 @@ export const ArticleHeader = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  margin-top: 15px;
+  margin-bottom: 10px;
 `;
-
-
 
 export const HeaderInfo = styled.div`
   display: flex;
@@ -52,6 +54,8 @@ export const Comments = styled.div`
 
 export const PostedAt = styled.div`
   color: ${COLORS.GRAY2};
+  font-weight: 400;
+  font-size: 16px;
 `;
 
 export const ArticleContent = styled.div`
@@ -64,6 +68,7 @@ export const Content = styled.div`
   overflow-x: hidden;
   overflow-y: hidden;
   height: 120px;
+  flex: 1;
   display: block;
   word-break: break-all;
   padding-right: 10px;

--- a/client/components/Main/Articlecard/index.style.ts
+++ b/client/components/Main/Articlecard/index.style.ts
@@ -50,6 +50,10 @@ export const Comments = styled.div`
   & > span {
     margin: 0 8px;
   }
+
+  & img {
+    padding-top: 2px !important;
+  }
 `;
 
 export const PostedAt = styled.div`

--- a/client/components/Main/Articlecard/index.tsx
+++ b/client/components/Main/Articlecard/index.tsx
@@ -32,7 +32,7 @@ export const ArticleCard = React.forwardRef<HTMLInputElement, Props>(
           <UserProfile profileimg={profileimg} nickname={nickname} author={author!} />
           <HeaderInfo>
             <Comments>
-              <Image src="/ico_comment.svg" width={20} height={20} />
+              <Image src="/ico_comment.svg" width={18} height={18} />
               <span>{comments}</span>
             </Comments>
             <PostedAt>{calcTime(date)}</PostedAt>

--- a/client/components/Main/Articlecard/index.tsx
+++ b/client/components/Main/Articlecard/index.tsx
@@ -26,27 +26,25 @@ interface Props {
 
 export const ArticleCard = React.forwardRef<HTMLInputElement, Props>(
   ({ id, description, author, nickname, date, comments, profileimg }: Props, ref) => (
-    <div ref={ref}>
-      <Link href={`/post/${id}`}>
-        <Wrapper>
-          <ArticleHeader>
-            <UserProfile profileimg={profileimg} nickname={nickname} author={author!} />
-            <HeaderInfo>
-              <Comments>
-                <Image src="/ico_comment.svg" width={20} height={20} />
-                <span>{comments}</span>
-              </Comments>
-              <PostedAt>{calcTime(date)}</PostedAt>
-            </HeaderInfo>
-          </ArticleHeader>
-          <hr />
-          <ArticleContent>
-            <Content>{description || '글 내용이 없어용!'}</Content>
-            <ArticleImage />
-          </ArticleContent>
-        </Wrapper>
-      </Link>
-    </div>
+    <Link href={`/post/${id}`}>
+      <Wrapper ref={ref}>
+        <ArticleHeader>
+          <UserProfile profileimg={profileimg} nickname={nickname} author={author!} />
+          <HeaderInfo>
+            <Comments>
+              <Image src="/ico_comment.svg" width={20} height={20} />
+              <span>{comments}</span>
+            </Comments>
+            <PostedAt>{calcTime(date)}</PostedAt>
+          </HeaderInfo>
+        </ArticleHeader>
+        <ArticleContent>
+          <Content>{description || '글 내용이 없어용!'}</Content>
+          <ArticleImage />
+        </ArticleContent>
+        <hr />
+      </Wrapper>
+    </Link>
   )
 );
 

--- a/client/components/Main/Mainsection/index.style.ts
+++ b/client/components/Main/Mainsection/index.style.ts
@@ -41,7 +41,7 @@ export const FakeButton = styled.button`
 `;
 
 export const ArticlesSection = styled.div`
-  background-color: ${COLORS.OFF_WHITE};
+  background-color: ${COLORS.WHITE};
   flex: 1;
 `;
 

--- a/client/components/Notification/NotificationCard/index.style.ts
+++ b/client/components/Notification/NotificationCard/index.style.ts
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import COLORS from '../../../styles/color';
 
 export const Container = styled.div`
   display: flex;
@@ -6,12 +7,19 @@ export const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-bottom: 2px solid #d7d7d7;
+  border-bottom: 2px solid ${COLORS.GRAY4};
+  background-color: ${COLORS.WHITE};
+
+  &:hover {
+    filter: brightness(0.9);
+  }
 `;
 export const Message = styled.div`
   display: flex;
   font-size: 1.2em;
+  margin: 0 10px;
 `;
 export const NotificationAt = styled.div`
   display: flex;
+  margin: 0 10px;
 `;

--- a/client/components/Notification/NotificationCard/index.tsx
+++ b/client/components/Notification/NotificationCard/index.tsx
@@ -10,13 +10,11 @@ interface NotificationData {
 }
 export const NotificationCard = React.forwardRef<HTMLInputElement, NotificationData>(
   ({ url, message, createdAt }: NotificationData, ref) => (
-    <div ref={ref}>
-      <Link href={url}>
-        <Container>
-          <Message>{message}</Message>
-          <NotificationAt>{calcTime(createdAt)}</NotificationAt>
-        </Container>
-      </Link>
-    </div>
+    <Link href={url}>
+      <Container ref={ref}>
+        <Message>{message}</Message>
+        <NotificationAt>{calcTime(createdAt)}</NotificationAt>
+      </Container>
+    </Link>
   )
 );

--- a/client/components/Notification/index.style.ts
+++ b/client/components/Notification/index.style.ts
@@ -1,4 +1,7 @@
 import styled from '@emotion/styled';
+import COLORS from '../../styles/color';
+import { displayColumn } from '../../styles/mixin';
+import { mainSectionSize } from '../../styles/theme';
 
 export const Wrapper = styled.div`
   height: 100%;
@@ -6,10 +9,32 @@ export const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
 `;
+
+export const TopBar = styled.header`
+  /* position: fixed; */
+  background-color: ${COLORS.WHITE};
+  height: 61px;
+  width: ${mainSectionSize}px;
+  border-bottom: 2px solid ${COLORS.GRAY3};
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  h1 {
+    flex: 1;
+    font-size: 22px;
+    font-weight: 500;
+    text-align: left;
+    color: ${COLORS.BLACK};
+    margin-left: 6px;
+    ${displayColumn}
+    margin-left: 33px;
+  }
+`;
+
 export const NotificationContainer = styled.div`
   overflow-y: scroll;
   flex: 1;
-  padding: 10px 40px 0px 40px;
+  padding: 0px 20px;
 `;
 
 export const ExceptionPage = styled.div`

--- a/client/components/Notification/index.tsx
+++ b/client/components/Notification/index.tsx
@@ -1,14 +1,9 @@
-import Router from 'next/router';
 import { useCallback, useRef, useState } from 'react';
-import { ButtonBack, TopBar } from '../../styles/common';
 import Paginator, { NEXT } from '../../utils/paginator';
-import { ExceptionPage, NotificationContainer, Wrapper } from './index.style';
+import { ExceptionPage, NotificationContainer, TopBar, Wrapper } from './index.style';
 import { NotificationCard } from './NotificationCard';
 
 export default function Notification() {
-  const goBack = () => {
-    Router.back();
-  };
   const [nextCursor, setNextCursor] = useState('START');
   const { loading, error, pages, next } = Paginator(`/api/notification/list/`, nextCursor);
   const observer = useRef<any>();
@@ -28,7 +23,6 @@ export default function Notification() {
   return (
     <Wrapper>
       <TopBar>
-        <ButtonBack type="button" onClick={goBack} />
         <h1>알림</h1>
       </TopBar>
       <NotificationContainer>

--- a/client/components/ProfileEdit/index.style.ts
+++ b/client/components/ProfileEdit/index.style.ts
@@ -9,24 +9,34 @@ export const Wrapper = styled.div`
 export const ProfileAndImgContainer = styled.div`
   display: flex;
   margin: 20px;
-  justify-content: center;
+  justify-content: space-around;
+  width: 80%;
 `;
 
-export const Avatar = styled('div')(({ src }: { src: string }) => ({
-  backgroundImage: `url(${src})`,
-  width: '146px',
-  height: '146px',
-  borderRadius: '146px',
-  backgroundColor: `${COLORS.GRAY3}`,
-  backgroundPosition: 'center center',
-  backgroundRepeat: 'no-repeat',
-  backgroundSize: 'cover',
-  margin: '10px',
-  aspectRatio: '1/1',
-  display: 'flex',
-  justifyContent: 'space-between',
-  flexDirection: 'column',
-}));
+interface avatarProps {
+  src: string;
+}
+
+export const Avatar = styled.div<avatarProps>`
+  ${(props) => props.src && `background-image: url(${props.src});`}
+  width: 146px;
+  height: 146px;
+  border-radius: 146px;
+  background-color: ${COLORS.GRAY3};
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: cover;
+  margin: 10px;
+  aspect-ratio: 1;
+  display: flex;
+  justify-content: space-between;
+  transition: all 0.2s;
+  cursor: pointer;
+  &:hover {
+    filter: brightness(0.7);
+    outline: ${COLORS.PRIMARY} solid 3px;
+  }
+`;
 
 export const ProfileArea = styled.div`
   margin: 30px 20px;
@@ -47,9 +57,32 @@ export const ChangeAvatarButton = styled.button`
   width: fit-content;
 `;
 
-export const InputsContainer = styled.div`
+export const ProfileImgForm = styled.form`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const EditSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+`;
+
+export const InputsContainer = styled.form`
   display: flex;
   justify-content: center;
+  flex-direction: column;
+  width: 80%;
+  & span {
+    margin: 0 20px;
+    user-select: none;
+    white-space: nowrap;
+  }
 `;
 
 export const ProfileImageInput = styled.input`
@@ -58,27 +91,35 @@ export const ProfileImageInput = styled.input`
 
 export const NicknameEditArea = styled.div`
   margin: 10px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
 `;
 
 export const BioEditArea = styled.div`
   margin: 10px;
   margin-top: 30px;
+  display: flex;
+  flex-direction: row;
 `;
 
 export const SubmitButton = styled.button`
   ${buttonStyle}
   width: fit-content;
-  margin-left: 45px;
+  margin: 0 45px;
+  align-self: flex-end;
 `;
 
 export const NicknameInput = styled.input`
   ${inputStyle}
 `;
 
-export const BioInput = styled.input`
+export const BioInput = styled.textarea`
   ${inputStyle}
   width: 400px;
   height: 200px;
+  resize: none;
 `;
 
 export const ErrorMessage = styled.li`
@@ -91,27 +132,4 @@ export const ErrorMessage = styled.li`
   margin-top: 10px;
   color: ${COLORS.RED};
   font-weight: 600;
-`;
-
-export const ChangeImageButton = styled.button`
-  border: 0px solid;
-  background-color: transparent;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  user-select: none;
-  cursor: pointer;
-  &:focus {
-    outline: none;
-  }
-  &:active {
-    filter: brightness(0.7);
-  }
-`;
-
-export const UpdateIcon = styled.div`
-  position: relative;
-  display: 'flex';
-  justify-content: 'space-between';
-  align-items: 'right';
 `;

--- a/client/components/ProfileEdit/index.tsx
+++ b/client/components/ProfileEdit/index.tsx
@@ -190,5 +190,4 @@ export default function ProfileEditSection() {
       </EditSection>
     </Wrapper>
   );
-  f;
 }

--- a/client/components/ProfileEdit/index.tsx
+++ b/client/components/ProfileEdit/index.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/legacy/image';
 import Router from 'next/router';
 import React, { ChangeEvent, RefObject, useEffect, useRef, useState } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
@@ -25,8 +24,8 @@ import {
   BioInput,
   ErrorMessage,
   ProfileImageInput,
-  UpdateIcon,
-  ChangeImageButton,
+  EditSection,
+  ProfileImgForm,
 } from './index.style';
 
 interface ProfileEditable {
@@ -102,11 +101,11 @@ export default function ProfileEditSection() {
     setMyProfile((prevProfile) => ({ ...prevProfile, nickname: e.target.value }));
   };
 
-  const handleBioChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleBioChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setMyProfile((prevProfile) => ({ ...prevProfile, bio: e.target.value }));
   };
 
-  const handleProfileImgSubmit = async () => {
+  const handleProfileImgSubmit = () => {
     // fetch('/api/user/')
     if (!profileImg) return;
     const formData = new FormData();
@@ -163,43 +162,33 @@ export default function ProfileEditSection() {
         </div>
         <h1>프로필 편집</h1>
       </TopBar>
-      <div>
-        <form onSubmit={handleSubmit(handleProfileImgSubmit)} style={{ width: '500px' }} encType="multipart/form-data">
+      <EditSection>
+        <ProfileImgForm onSubmit={handleSubmit(handleProfileImgSubmit)} encType="multipart/form-data">
           <ProfileAndImgContainer>
-            <Avatar src={previewImg ?? myProfile.profileimg}>
-              <div>&nbsp;</div>
-              <UpdateIcon>
-                <div>&nbsp;</div>
-                <ProfileImageInput type="file" ref={selectFile} onChange={handleImg} accept="image/*" />
-                <ChangeImageButton type="button" onClick={() => selectFile.current!.click()}>
-                  <Image src="/profile_img.svg" alt="Profile" width={50} height={60} priority />
-                </ChangeImageButton>
-              </UpdateIcon>
-            </Avatar>
-
+            <ProfileImageInput type="file" ref={selectFile} onChange={handleImg} accept="image/*" />
+            <Avatar src={previewImg ?? myProfile.profileimg} onClick={() => selectFile.current!.click()} />
             <ProfileArea>
               <ProfileUserid>{myProfile.userid}</ProfileUserid>
               <ProfileEmail>{myProfile.email}</ProfileEmail>
-              <ChangeAvatarButton type="submit">프로필 사진 바꾸기</ChangeAvatarButton>
+              {previewImg && <ChangeAvatarButton type="submit">프로필 사진 저장</ChangeAvatarButton>}
             </ProfileArea>
           </ProfileAndImgContainer>
-        </form>
-        <InputsContainer>
-          <form onSubmit={handleSubmit(handleProfileSubmit)} style={{ width: '500px' }}>
-            <NicknameEditArea>
-              별명:
-              <NicknameInput {...register('nickname')} value={myProfile.nickname} onChange={handleNicknameChange} />
-              <ErrorMessage>{errors.nickname && (errors.nickname.message as string)}</ErrorMessage>
-            </NicknameEditArea>
-            <BioEditArea>
-              소개:
-              <BioInput {...register('bio')} value={myProfile.bio} onChange={handleBioChange} />
-              <ErrorMessage>{errors.bio && (errors.bio.message as string)}</ErrorMessage>
-            </BioEditArea>
-            <SubmitButton type="submit">저장</SubmitButton>
-          </form>
+        </ProfileImgForm>
+        <InputsContainer onSubmit={handleSubmit(handleProfileSubmit)}>
+          <NicknameEditArea>
+            <span>별명:</span>
+            <NicknameInput {...register('nickname')} value={myProfile.nickname} onChange={handleNicknameChange} />
+          </NicknameEditArea>
+          <ErrorMessage>{errors.nickname && (errors.nickname.message as string)}</ErrorMessage>
+          <BioEditArea>
+            <span>소개:</span>
+            <BioInput {...register('bio')} value={myProfile.bio} onChange={handleBioChange} />
+          </BioEditArea>
+          <ErrorMessage>{errors.bio && (errors.bio.message as string)}</ErrorMessage>
+          <SubmitButton type="submit">저장</SubmitButton>
         </InputsContainer>
-      </div>
+      </EditSection>
     </Wrapper>
   );
+  f;
 }

--- a/client/components/ReadPost/ParentPost/index.style.ts
+++ b/client/components/ReadPost/ParentPost/index.style.ts
@@ -16,16 +16,16 @@ export const Author = styled.div`
 export const AuthorDetail = styled.div`
   display: flex;
   margin-bottom: 20px;
-  #name {
+  .name {
     font-weight: 500;
     font-size: 18px;
   }
-  #user-id {
+  .user-id {
     margin: 3px 3px;
     color: ${COLORS.GRAY1};
     font-size: 14px;
   }
-  #time {
+  .time {
     margin: 3px 1px;
     margin-left: 2px;
     color: ${COLORS.GRAY1};
@@ -34,13 +34,31 @@ export const AuthorDetail = styled.div`
 `;
 
 export const ContentBox = styled.div`
-  width: 81%;
-  ${markdownStyle}
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+
+  & > a {
+    flex: 1;
+  }
+
+  & .content {
+    ${markdownStyle}
+    width: 100%;
+  }
 `;
 
 export const HeaderBox = styled.div`
-  width: 95%;
+  width: 100%;
   height: 50px;
   display: flex;
   justify-content: space-between;
+  flex-direction: row;
+`;
+
+export const ParentTree = styled.div`
+  width: 1px;
+  margin: 0px 39px;
+  border: 1px solid ${COLORS.GRAY3};
+  height: calc(100% + 15px);
 `;

--- a/client/components/ReadPost/ParentPost/index.tsx
+++ b/client/components/ReadPost/ParentPost/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { calcTime } from '../../../utils/calctime';
-import { Author, AuthorDetail, Wrapper, ContentBox, HeaderBox } from './index.style';
+import { Author, AuthorDetail, Wrapper, ContentBox, HeaderBox, ParentTree } from './index.style';
 import ProfileImg from '../UserProfile/ProfileImg';
 import type { Parent } from '../../../types/Post';
 import renderMarkdown from '../../../utils/markdown';
@@ -19,16 +19,17 @@ export default function ParentPost({ post }: { post: Parent }) {
           <Author>
             <ProfileImg imgUrl={post.authorDetail.profileimg} />
             <AuthorDetail>
-              <div id="name">{post.authorDetail.nickname || '작성자 이름'}</div>
-              <div id="user-id">@{post.author || '작성자 아이디'}</div>
-              <div id="time">· {calcTime(post.createdAt)}</div>
+              <div className="name">{post.authorDetail.nickname || '작성자 이름'}</div>
+              <div className="user-id">@{post.author || '작성자 아이디'}</div>
+              <div className="time">· {calcTime(post.createdAt)}</div>
             </AuthorDetail>
           </Author>
         </Link>
       </HeaderBox>
       <ContentBox>
+        <ParentTree />
         <Link href={`/post/${post._id}`}>
-          <div id="content" ref={contentRef}>
+          <div className="content" ref={contentRef}>
             {post.description}
           </div>
         </Link>

--- a/client/components/ReadPost/index.style.ts
+++ b/client/components/ReadPost/index.style.ts
@@ -3,7 +3,7 @@ import COLORS from '../../styles/color';
 import { markdownStyle, mainSectionStyle, displayCenter } from '../../styles/mixin';
 
 export const HeaderBox = styled.div`
-  width: 95%;
+  width: 100%;
   display: flex;
   justify-content: space-between;
   border-bottom: 1px solid ${COLORS.GRAY4};
@@ -21,6 +21,7 @@ export const PostContent = styled.div`
   flex-direction: column;
   align-items: center;
   -ms-overflow-style: none;
+  padding: 8px 15px;
   &::-webkit-scrollbar {
     display: none;
   }
@@ -35,14 +36,14 @@ export const MainContentBox = styled.div`
 `;
 
 export const ContentBox = styled.div`
-  width: 92%;
+  width: 100%;
   margin-top: 20px;
   ${markdownStyle}
   font-size: 18px;
 `;
 
 export const CommentBox = styled.div`
-  width: 95%;
+  width: 100%;
   margin-top: 40px;
   border-top: 1px solid ${COLORS.GRAY4};
   display: flex;

--- a/client/components/User/Profile/ProfileCounter/index.tsx
+++ b/client/components/User/Profile/ProfileCounter/index.tsx
@@ -11,7 +11,7 @@ interface Props {
 function ProfileCounter({ ...props }: Props) {
   let JSX = (
     <>
-      {props.label} {props.counter}
+      {props.label} <span>{props.counter}</span>
     </>
   );
   if (props.url !== '') JSX = <Link href={props.url}>{JSX}</Link>;

--- a/client/components/User/Profile/index.style.ts
+++ b/client/components/User/Profile/index.style.ts
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import COLORS from '../../../styles/color';
+import { buttonStyle } from '../../../styles/mixin';
 
 export const ProfileContainer = styled.div`
   width: 100%;
@@ -33,9 +34,16 @@ export const ProfileNames = styled.div`
 
 export const ProfileNickname = styled.div`
   font-size: 32px;
+  font-weight: 600;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  color: ${COLORS.BLACK};
 `;
 
 export const ProfileUserid = styled.div`
+  margin-top: 5px;
+  color: ${COLORS.GRAY2};
   &:before {
     content: '@';
   }
@@ -44,6 +52,9 @@ export const ProfileUserid = styled.div`
 export const ProfileCounters = styled.div`
   margin: 20px 0;
   display: flex;
+  & span {
+    font-weight: 500;
+  }
 `;
 
 export const ProfileBio = styled.div`
@@ -51,6 +62,7 @@ export const ProfileBio = styled.div`
 `;
 
 export const ProfileEditButton = styled.button`
+  ${buttonStyle}
   background-color: ${COLORS.PRIMARY};
   border-radius: 4px;
   border: none;


### PR DESCRIPTION
아래 이슈에 의한 작업내용입니다.
- https://github.com/boostcampwm-2022/web34-moheyum/issues/172
- 아직 미작업 부분이 남아있어 merge 후에도 브랜치를 삭제하지 않습니다.

## 포함된 수정사항들
- ArticleCard와 MainSection을 수정하였습니다.
- 게시글을 읽을 때 댓글 - 원글간의 관계를 좀 더 가시적으로 표시하였습니다.
- 알림 페이지 레이아웃을 일부 수정하였습니다.
- 팔로잉 / 팔로워 화면에서 뒤로가기 버튼을 누르면 유저 프로필로 올바르게 나가집니다.

## 확인해야 할 것들
- 언제부턴가 브라우저 크기를 줄이면 Sidebar가 작아지는 대신 MainSection에 밀려서 사라져버립니다.
- 프로필 수정 부분은 리팩토링하는게 나을 것 같아서 보류하였습니다.
  - 프로필 사진 - 닉네임/자기소개 부분이 레이아웃이 맞춰지질 않습니다 ;ㅅ;..
- 에디터 디자인은 내일 마저 하겠읍니다..