### PR TITLE
feat(FE): 토스트 메시지 구현

### DIFF
--- a/client/atom/index.ts
+++ b/client/atom/index.ts
@@ -1,4 +1,5 @@
 import { atom } from 'recoil';
+import { ToastMessage } from '../types/Toast';
 
 interface AuthedUser {
   logined: boolean;
@@ -22,4 +23,9 @@ export const authedUser = atom<AuthedUser>({
 export const newNotification = atom({
   key: 'state',
   default: false,
+});
+
+export const toastMessageList = atom<ToastMessage[]>({
+  key: 'toast',
+  default: [],
 });

--- a/client/components/AuthGuard.tsx
+++ b/client/components/AuthGuard.tsx
@@ -29,7 +29,7 @@ export default function AuthGuard({ children, noRedirect }: React.PropsWithChild
       setAuthedUserInfo({ logined: true, ...result.data });
       setAuthorized(true);
     }
-    if (result.message === 'Unauthorized') {
+    if (response.statusText === 'Unauthorized') {
       setAuthorized(false);
       setAuthedUserInfo(defaultAuthedUser);
       if (!noRedirect)

--- a/client/components/Main/SideBar/index.tsx
+++ b/client/components/Main/SideBar/index.tsx
@@ -29,7 +29,7 @@ export default function SideBar({ notiState }: React.PropsWithChildren<SideBarPr
   const authedUserInfo = useRecoilValue(authedUser);
   const [newNotiState, setNewNotiState] = useRecoilState(newNotification);
   useEffect(() => {
-    const eventSource = new EventSource('/api/alarm');
+    const eventSource = new EventSource('/api/event');
     if (!notiState) {
       eventSource.onmessage = (event) => {
         setNewNotiState(event.data);

--- a/client/components/Notification/index.tsx
+++ b/client/components/Notification/index.tsx
@@ -17,7 +17,7 @@ export default function Notification() {
     Router.reload();
   };
   useEffect(() => {
-    const eventSource = new EventSource('/api/alarm');
+    const eventSource = new EventSource('/api/event');
     eventSource.onmessage = (event) => {
       setNewNotiState(event.data);
       setNewState(event.data);

--- a/client/components/Toast/ToastMessage.tsx
+++ b/client/components/Toast/ToastMessage.tsx
@@ -8,11 +8,7 @@ interface ToastProps {
 }
 
 function ToastMessageInstance({ message }: ToastProps) {
-  return (
-    <MessageWrapper>
-      {message.message}: {message.key}
-    </MessageWrapper>
-  );
+  return <MessageWrapper>{message.message}</MessageWrapper>;
 }
 
 export default React.memo(ToastMessageInstance, (prev, next) => prev.message.key === next.message.key);

--- a/client/components/Toast/ToastMessage.tsx
+++ b/client/components/Toast/ToastMessage.tsx
@@ -1,0 +1,39 @@
+import styled from '@emotion/styled';
+import React from 'react';
+import COLORS from '../../styles/color';
+import { ToastMessage } from '../../types/Toast';
+
+interface ToastProps {
+  message: ToastMessage;
+}
+
+function ToastMessageInstance({ message }: ToastProps) {
+  return (
+    <MessageWrapper>
+      {message.message}: {message.key}
+    </MessageWrapper>
+  );
+}
+
+export default React.memo(ToastMessageInstance, (prev, next) => prev.message.key === next.message.key);
+
+const MessageWrapper = styled.div`
+  max-width: 40%;
+  border-radius: 10px;
+  background-color: rgba(0, 0, 0, 0.7);
+  padding: 20px;
+  margin: 10px 30px;
+  color: ${COLORS.WHITE};
+  text-align: center;
+
+  transition: all 0.3s ease;
+  animation: popIn 0.3s;
+  @keyframes popIn {
+    from {
+      transform: translateY(500%);
+    }
+    to {
+      transform: translateY(0);
+    }
+  }
+`;

--- a/client/components/Toast/index.tsx
+++ b/client/components/Toast/index.tsx
@@ -1,0 +1,45 @@
+import styled from '@emotion/styled';
+import React, { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { toastMessageList } from '../../atom';
+import ToastMessageInstance from './ToastMessage';
+
+export default function ToastController() {
+  const [messageList, setMessageList] = useRecoilState(toastMessageList);
+
+  useEffect(() => {
+    if (messageList.length === 0) return undefined;
+    const timer = setTimeout(() => {
+      clearTimeout(timer);
+      closeToast();
+    }, 3000);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [messageList]);
+
+  const closeToast = () => {
+    const newList = messageList.slice(1);
+    setMessageList(newList);
+  };
+
+  return (
+    <ToastMessageContainer>
+      {messageList.map((msg) => (
+        <ToastMessageInstance message={msg} key={msg.key} />
+      ))}
+    </ToastMessageContainer>
+  );
+}
+
+const ToastMessageContainer = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  position: fixed;
+  padding: 20px;
+  pointer-events: none;
+`;

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -11,6 +11,7 @@ import theme from '../styles/theme';
 import globalStyle from '../styles/global';
 import Frame from '../styles/frame';
 import SideBar from '../components/Main/SideBar';
+import ToastController from '../components/Toast';
 
 const NoSideBar = ['/login', '/signup'];
 
@@ -30,6 +31,7 @@ export default function App({ Component, pageProps }: AppProps) {
               <Component {...pageProps} />
             </ComponentWrapper>
           </Frame>
+          <ToastController />
         </AppStyle>
       </RecoilRoot>
     </ThemeProvider>

--- a/client/types/Toast.ts
+++ b/client/types/Toast.ts
@@ -1,0 +1,4 @@
+export interface ToastMessage {
+  key: string;
+  message: string;
+}


### PR DESCRIPTION
아래 이슈에 대한 작업 내용입니다.
- https://github.com/boostcampwm-2022/web34-moheyum/issues/198

![toast](https://user-images.githubusercontent.com/46566891/205938880-8561059d-337f-46f9-b443-fb1bb11a20c4.gif)
캡쳐를 잘못 했는데 아무튼 3초 후에 메시지가 사라집니다.  
메시지를 표시할 위치와 시간에 대해서는 고민할 필요가 있겠네요.  
최초 목표였던 새 알림 메시지는 브랜치 생성 당시 dev 브랜치에서 SSE가 제대로 작동하지 않아 적용하지 못했습니다.  
merge 후 작업해야 할 듯..