### PR TITLE
Feature/fe/213 applying toasts

### DIFF
--- a/client/components/Follow/FollowMember/index.tsx
+++ b/client/components/Follow/FollowMember/index.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import React, { useEffect, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 import { authedUser } from '../../../atom';
+import useToast from '../../../hooks/useToast';
 import { httpPost, httpDelete, httpGet } from '../../../utils/http';
 import { Avatar, Button, ButtonArea, Container, Information, UserId, UserNickname } from './index.style';
 
@@ -16,6 +17,7 @@ export const FollowMember = React.forwardRef<HTMLInputElement, UserData>(
   ({ userid, nickname, profileimg, displayButton }: UserData, ref) => {
     const [following, setFollowing] = useState(false);
     const authedUserInfo = useRecoilValue(authedUser);
+    const toast = useToast();
 
     useEffect(() => {
       if (authedUserInfo.logined) {
@@ -32,7 +34,7 @@ export const FollowMember = React.forwardRef<HTMLInputElement, UserData>(
           : await httpPost(`/follow/following/${userid}`, {});
         if (response.message === 'success') setFollowing((prev) => !prev);
       } catch (e) {
-        alert(`Follow ERROR: ${e}`);
+        toast.addMessage(`Follow ERROR: ${e}`);
       }
     };
 

--- a/client/components/Idinquiry/index.tsx
+++ b/client/components/Idinquiry/index.tsx
@@ -17,6 +17,7 @@ import {
   EmailRowMessage,
   CompleteBox,
 } from './index.style';
+import useToast from '../../hooks/useToast';
 
 const schema = yup.object().shape({
   email: yup.string().required('이메일을 입력하세요.').email('이메일 형식에 맞지 않습니다.'),
@@ -38,10 +39,13 @@ export default function Idinquiry() {
   const onChangeEmail = (e: ChangeEvent<HTMLInputElement>): void => {
     setUserEmail(e.target.value);
   };
+
+  const toast = useToast();
+
   const handleInpuiry = async () => {
     const response = await httpPost('/auth/id-inquiry', { email: userEmail });
     if (response.message !== 'success') {
-      alert('아이디를 찾을 수 없습니다.');
+      toast.addMessage('아이디를 찾을 수 없습니다.');
       return;
     }
     setUserId(response.data);

--- a/client/components/Login/Login/index.tsx
+++ b/client/components/Login/Login/index.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { httpPost } from '../../../utils/http';
 import { Box, FindAccount, SignUp, Wrapper, Title } from './index.style';
 import COLORS from '../../../styles/color';
+import useToast from '../../../hooks/useToast';
 
 function changeBorder(inputRef: RefObject<HTMLInputElement>, color: string) {
   const { current } = inputRef;
@@ -31,6 +32,7 @@ function isInputExist(
 }
 
 export default function Login() {
+  const toast = useToast();
   const [account, setAccount] = useState({
     id: '',
     pw: '',
@@ -58,16 +60,16 @@ export default function Login() {
       }
       switch (response.statusCode) {
         case 401:
-          alert('아이디 또는 비밀번호를 잘못 입력했습니다.\n입력하신 내용을 다시 확인해주세요.');
+          toast.addMessage('아이디 또는 비밀번호를 잘못 입력했습니다.\n입력하신 내용을 다시 확인해주세요.');
           break;
         case 422:
-          alert('입력하신 형식이 맞지 않습니다.\n아이디: 영어,숫자,_ 포함 4~16글자');
+          toast.addMessage('입력하신 형식이 맞지 않습니다.\n아이디: 영어,숫자,_ 포함 4~16글자');
           break;
         default:
-          alert(`로그인 ERROR statusCode: ${response.statusCode}\nERROR message: ${response.message}`);
+          toast.addMessage(`로그인 ERROR statusCode: ${response.statusCode}\nERROR message: ${response.message}`);
       }
     } catch (err) {
-      alert(`로그인 실패 ERROR message: ${err as string}`);
+      toast.addMessage(`로그인 실패 ERROR message: ${err as string}`);
       Router.push('/login');
     }
   };

--- a/client/components/MainSection/Articlecard/index.tsx
+++ b/client/components/MainSection/Articlecard/index.tsx
@@ -43,7 +43,7 @@ export const ArticleCard = React.forwardRef<HTMLInputElement, Props>(
           <Content>{description || '글 내용이 없어용!'}</Content>
           {thumbnail && (
             <ArticleImageContainer>
-              <Image src={thumbnail} layout="fill" alt="post thumbnail" />
+              <Image src={thumbnail} fill sizes="100%, 100%" alt="post thumbnail" />
             </ArticleImageContainer>
           )}
         </ArticleContent>

--- a/client/components/MyAccount/index.tsx
+++ b/client/components/MyAccount/index.tsx
@@ -17,6 +17,7 @@ import {
   SubmitPassword,
   Wrapper,
 } from './index.style';
+import useToast from '../../hooks/useToast';
 
 const goBack = () => {
   Router.back();
@@ -40,6 +41,7 @@ const schema = yup.object().shape({
 });
 
 export default function MyAccount() {
+  const toast = useToast();
   const [formInput, setFormInput] = useState({
     prevPassword: '',
     newPassword: '',
@@ -78,7 +80,7 @@ export default function MyAccount() {
     const confirmed = confirm('회원 탈퇴를 하시겠습니까?\n삭제된 계정은 복구할 수 없습니다.');
     if (confirmed) {
       await httpDelete(`/auth`);
-      alert(`탈퇴가 완료되었습니다.\n이용해주셔서 감사합니다.`);
+      toast.addMessage(`탈퇴가 완료되었습니다.\n이용해주셔서 감사합니다.`);
       Router.push('/');
     }
   };

--- a/client/components/ProfileEdit/index.tsx
+++ b/client/components/ProfileEdit/index.tsx
@@ -27,6 +27,7 @@ import {
   ProfileImage,
   ButtonBox,
 } from './index.style';
+import useToast from '../../hooks/useToast';
 
 interface ProfileEditable {
   nickname: string;
@@ -65,6 +66,8 @@ export default function ProfileEditSection() {
   const goBack = () => {
     Router.back();
   };
+
+  const toast = useToast();
 
   const authedUserInfo = useRecoilValue(authedUser);
   const setAuthedUserInfo = useSetRecoilState(authedUser);
@@ -132,8 +135,7 @@ export default function ProfileEditSection() {
         profileSubmit();
       })
       .catch((e) => {
-        alert(e);
-        console.error(e);
+        toast.addMessage(e);
       });
   };
 
@@ -143,8 +145,7 @@ export default function ProfileEditSection() {
       bio: myProfile.bio,
     })
       .catch((e) => {
-        alert('프로필 편집에 실패했습니다.');
-        console.error(e);
+        toast.addMessage(`프로필 편집에 실패했습니다.\n${e}`);
       })
       .finally(() => {
         goBack();

--- a/client/components/Pwinquiry/index.tsx
+++ b/client/components/Pwinquiry/index.tsx
@@ -18,6 +18,7 @@ import {
   EmailRowMessage,
   CompleteBox,
 } from './index.style';
+import useToast from '../../hooks/useToast';
 
 const schema = yup.object().shape({
   id: yup
@@ -37,6 +38,8 @@ export default function Pwinquiry() {
   } = useForm({
     resolver: yupResolver(schema),
   });
+  const toast = useToast();
+
   const goBack = () => {
     Router.back();
   };
@@ -55,16 +58,16 @@ export default function Pwinquiry() {
     const response = await httpPost('/auth/password-inquiry', { email: userInfo.email, userid: userInfo.id });
     switch (response.statusCode) {
       case 422:
-        alert(`없는 아이디입니다.${response.statusCode}: ${response.message}`);
+        toast.addMessage(`없는 아이디입니다.${response.statusCode}: ${response.message}`);
         break;
       case 404:
-        alert(`없는 이메일입니다.${response.statusCode}: ${response.message}`);
+        toast.addMessage(`없는 이메일입니다.${response.statusCode}: ${response.message}`);
         break;
       case 200:
         setSendSuccess(true);
         break;
       default:
-        alert(`서버 오류. ${response.statusCode}: ${response.message}`);
+        toast.addMessage(`서버 오류. ${response.statusCode}: ${response.message}`);
     }
   };
   return (

--- a/client/components/ReadPost/MainPost/index.tsx
+++ b/client/components/ReadPost/MainPost/index.tsx
@@ -17,11 +17,13 @@ import {
   DropDown,
   PostButton,
 } from './index.style';
+import useToast from '../../../hooks/useToast';
 
 export default function MainPost({ postData }: { postData: PostProps }) {
   const authedUserInfo = useRecoilValue(authedUser);
   const contentRef = useRef<HTMLDivElement>(null);
   const [dropDownDisplay, setDropDownDisplay] = useState<boolean>(false);
+  const toast = useToast();
 
   useEffect(() => {
     if (!contentRef.current) return;
@@ -31,7 +33,7 @@ export default function MainPost({ postData }: { postData: PostProps }) {
     setDropDownDisplay(false);
     const response = await httpDelete(`/post/${postData._id}`);
     if (response.statusCode !== 200) {
-      alert(`게시글 삭제에 실패하였습니다. ${response.message}`);
+      toast.addMessage(`게시글 삭제에 실패하였습니다. ${response.message}`);
     } else {
       Router.push('/');
     }

--- a/client/components/SideBar/index.tsx
+++ b/client/components/SideBar/index.tsx
@@ -14,15 +14,7 @@ const menuList = [
   { routeSrc: '/search', imgSrc: '/ico_search.svg', text: '검색', avatar: false },
 ];
 
-type SideBarProps = {
-  notiState?: boolean;
-};
-
-SideBar.defaultProps = {
-  notiState: false,
-};
-
-export default function SideBar({ notiState }: React.PropsWithChildren<SideBarProps>) {
+export default function SideBar() {
   const [dropdownState, setdropdownState] = useState<boolean>(false);
   const toast = useToast();
 
@@ -33,18 +25,15 @@ export default function SideBar({ notiState }: React.PropsWithChildren<SideBarPr
   const [newNotiState, setNewNotiState] = useRecoilState(newNotification);
   useEffect(() => {
     const eventSource = new EventSource('/api/event');
-    if (!notiState) {
-      eventSource.onmessage = (event) => {
-        setNewNotiState(event.data);
-        toast.addMessage('새 알림이 도착했습니다.');
-      };
-      eventSource.onerror = (error) => {
-        // console.error('SSE error', error);
-        toast.addMessage(`SSE error : ${error}`);
-      };
-    }
+    eventSource.onmessage = (event) => {
+      setNewNotiState(event.data);
+      toast.addMessage('새 알림이 도착했습니다.');
+    };
+    eventSource.onerror = (error) => {
+      toast.addMessage(`SSE error : ${error}`);
+    };
     return () => eventSource.close();
-  }, [notiState]);
+  }, []);
 
   return (
     <Wrapper>

--- a/client/components/SideBar/index.tsx
+++ b/client/components/SideBar/index.tsx
@@ -6,6 +6,7 @@ import Title from './Title';
 import { authedUser, newNotification } from '../../atom';
 import { Setting, SideMenuBox, Wrapper } from './index.style';
 import SideBarDropdown from './SideBarDropdown';
+import useToast from '../../hooks/useToast';
 
 const menuList = [
   { routeSrc: '/', imgSrc: '/ico_home.svg', text: '홈', avatar: false },
@@ -23,6 +24,8 @@ SideBar.defaultProps = {
 
 export default function SideBar({ notiState }: React.PropsWithChildren<SideBarProps>) {
   const [dropdownState, setdropdownState] = useState<boolean>(false);
+  const toast = useToast();
+
   const showSettingdropdown = () => {
     setdropdownState(!dropdownState);
   };
@@ -33,9 +36,11 @@ export default function SideBar({ notiState }: React.PropsWithChildren<SideBarPr
     if (!notiState) {
       eventSource.onmessage = (event) => {
         setNewNotiState(event.data);
+        toast.addMessage('새 알림이 도착했습니다.');
       };
       eventSource.onerror = (error) => {
-        console.error('SSE error', error);
+        // console.error('SSE error', error);
+        toast.addMessage(`SSE error : ${error}`);
       };
     }
     return () => eventSource.close();

--- a/client/components/Signup/index.tsx
+++ b/client/components/Signup/index.tsx
@@ -20,6 +20,7 @@ import {
   SignupVerifyMessage,
   SubmitButton,
 } from './index.style';
+import useToast from '../../hooks/useToast';
 
 // 페이지 변경되거나 추가되면 여기도 업데이트 필요.
 const urlList = ['signup', 'post', 'notification', 'login', 'myAccount', 'search', 'write', 'idinquiry', 'pwinquiry'];
@@ -76,6 +77,7 @@ export default function SignupModal() {
     verify: '',
   });
 
+  const toast = useToast();
   const [startVerify, setStartVerify] = useState<boolean>(false);
   const [verified, setVerified] = useState<boolean>(false);
   const [timer, setTimer] = useState<number>(-1);
@@ -168,7 +170,9 @@ export default function SignupModal() {
       password: formValues.password,
     });
     if (response.statusCode !== 200) {
-      alert(`오류가 발생했습니다.\nERROR statusCode: ${response.statusCode}\nERROR message: ${response.message}`);
+      toast.addMessage(
+        `오류가 발생했습니다.\nERROR statusCode: ${response.statusCode}\nERROR message: ${response.message}`
+      );
       setVerified(false);
       return;
     }
@@ -177,7 +181,7 @@ export default function SignupModal() {
       password: formValues.password,
     });
     if (signinResponse.statusCode !== 200) {
-      alert(
+      toast.addMessage(
         `회원 가입에 성공했으나 로그인에 실패했습니다.\nERROR statusCode: ${signinResponse.statusCode}\nERROR message: ${signinResponse.message}`
       );
       return;

--- a/client/components/Write/Editor/index.tsx
+++ b/client/components/Write/Editor/index.tsx
@@ -23,6 +23,7 @@ import {
   Wrapper,
 } from './index.style';
 import PostProps from '../../../types/Post';
+import useToast from '../../../hooks/useToast';
 
 interface Props {
   parentPostData?: {
@@ -67,6 +68,8 @@ export default function Editor({ parentPostData, modifyPostData }: Props) {
   const [inputUserId, setInputUserId] = useState<string>('');
   const [selectUser, setSelectUser] = useState<number>(0);
 
+  const toast = useToast();
+
   // 실시간 미리보기를 활성화하려면 이걸 키고 preview element의 렌더링 조건을 tabIndex === 0 으로 바꿔주세요
   // useEffect(() => {
   //   if (!previewRef.current) return;
@@ -87,7 +90,9 @@ export default function Editor({ parentPostData, modifyPostData }: Props) {
         parentPost: modifyPostData.parentPost,
       });
       if (result.statusCode !== 200) {
-        alert(`글 수정에 실패했습니다.\nERROR statusCode: ${result.statusCode}\nERROR message: ${result.message}`);
+        toast.addMessage(
+          `글 수정에 실패했습니다.\nERROR statusCode: ${result.statusCode}\nERROR message: ${result.message}`
+        );
         return;
       }
       Router.push(`/post/${modifyPostData._id}`);
@@ -102,7 +107,9 @@ export default function Editor({ parentPostData, modifyPostData }: Props) {
       mentions: Array.from(removeDup),
     });
     if (result.statusCode !== 200) {
-      alert(`글 작성에 실패했습니다.\nERROR statusCode: ${result.statusCode}\nERROR message: ${result.message}`);
+      toast.addMessage(
+        `글 작성에 실패했습니다.\nERROR statusCode: ${result.statusCode}\nERROR message: ${result.message}`
+      );
       return;
     }
     Router.back();
@@ -406,9 +413,9 @@ export default function Editor({ parentPostData, modifyPostData }: Props) {
               setContent(data); // setContent를 안하면 프리뷰에 반영이 안됩니다..
             }
           })
-          .catch((e) => alert(`이미지 업로드에 실패하였습니다. Error Message: ${e}`));
+          .catch((e) => toast.addMessage(`이미지 업로드에 실패하였습니다. Error Message: ${e}`));
       } else {
-        alert(`이미지 포맷을 확인해주세요.업로드 된 파일 이름 ${files[0].name} / 포맷 ${format}`);
+        toast.addMessage(`이미지 포맷을 확인해주세요.업로드 된 파일 이름 ${files[0].name} / 포맷 ${format}`);
       }
     }
   };

--- a/client/hooks/useToast.ts
+++ b/client/hooks/useToast.ts
@@ -1,0 +1,13 @@
+import { useRecoilState } from 'recoil';
+import { toastMessageList } from '../atom';
+
+export default function useToast() {
+  const [toastList, setToastList] = useRecoilState(toastMessageList);
+
+  const addMessage = (message: string, key?: string) => {
+    const newMessage = { message, key: key ?? `${Math.floor(Math.random())}${message}` };
+    setToastList([...toastList, newMessage]);
+  };
+
+  return { addMessage };
+}

--- a/client/utils/markdown/rules.ts
+++ b/client/utils/markdown/rules.ts
@@ -123,7 +123,6 @@ export function doParseForArticleCard(str: string): MarkdownWithoutStyle {
   const img = /<img src="(.+?)".+?\/>/g.exec(withStyle);
   if (img) {
     [, result.thumbnail] = img;
-    console.log(withStyle);
   }
 
   return result;


### PR DESCRIPTION
아래 이슈에 따른 작업 내용입니다.
- https://github.com/boostcampwm-2022/web34-moheyum/issues/213
작업하면서 `next/legacy/image`에서 사용하던 property가 있는 부분을 같이 수정했습니다.  
앞으로 toast 메시지는 아래와 같이 사용할 수 있습니다.
```typescript
const toast = useToast();
toast.addMessage('메시지', 'key');
```
`key`는 생략할 수 있습니다.