### PR TITLE
Refactor/fe/minor fixes

### DIFF
--- a/client/components/CommentPost/index.tsx
+++ b/client/components/CommentPost/index.tsx
@@ -16,6 +16,7 @@ export default function CommentPost({ response }: { response: Props }) {
   return (
     <ContentWrapper>
       <MainPostWrapper ref={mainPostRef}>
+        <ParentFilter />
         <MainPost postData={response.data.post} />
       </MainPostWrapper>
       <CommentEditor>
@@ -26,7 +27,7 @@ export default function CommentPost({ response }: { response: Props }) {
 }
 const ContentWrapper = styled.div`
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
   display: flex;
   flex: 1;
   flex-direction: column;
@@ -35,19 +36,34 @@ const ContentWrapper = styled.div`
 
 const MainPostWrapper = styled.div`
   width: 100%;
+  max-height: 350px;
   padding: 8px 15px;
+  overflow-y: hidden;
+  overflow-x: hidden;
+  position: relative;
 `;
 
 const CommentEditor = styled.div`
-  overflow-y: scroll;
   width: 100%;
   min-height: 300px;
   flex: 1;
+  flex-direction: column;
+  display: flex;
   border-top: 2px solid ${COLORS.GRAY3};
   margin-top: 20px;
   padding-top: 20px;
   -ms-overflow-style: none;
+  z-index: 2;
   &::-webkit-scrollbar {
     display: none;
   }
+`;
+
+const ParentFilter = styled.div`
+  width: 100%;
+  height: 400px;
+  position: absolute;
+  background: linear-gradient(transparent 20%, ${COLORS.WHITE});
+  margin-left: -15px;
+  margin-top: -8px;
 `;

--- a/client/components/ReadPost/ParentPost/index.style.ts
+++ b/client/components/ReadPost/ParentPost/index.style.ts
@@ -45,6 +45,8 @@ export const ContentBox = styled.div`
   & .content {
     ${markdownStyle}
     width: 100%;
+    max-height: 350px;
+    overflow-y: hidden;
   }
 `;
 
@@ -54,6 +56,12 @@ export const HeaderBox = styled.div`
   display: flex;
   justify-content: space-between;
   flex-direction: row;
+  & > a {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    position: relative;
+  }
 `;
 
 export const ParentTreeContainer = styled.div`
@@ -61,6 +69,7 @@ export const ParentTreeContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: 2;
 `;
 
 export const ParentTree = styled.div`
@@ -68,4 +77,11 @@ export const ParentTree = styled.div`
   margin: 0px 33px;
   border: 1px solid ${COLORS.GRAY3};
   height: calc(100% + 15px);
+`;
+
+export const ParentFilter = styled.div`
+  width: 100%;
+  height: 400px;
+  position: absolute;
+  background: linear-gradient(transparent 20%, ${COLORS.WHITE});
 `;

--- a/client/components/ReadPost/ParentPost/index.tsx
+++ b/client/components/ReadPost/ParentPost/index.tsx
@@ -1,7 +1,16 @@
 import React, { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { calcTime } from '../../../utils/calctime';
-import { Author, AuthorDetail, Wrapper, ContentBox, HeaderBox, ParentTree, ParentTreeContainer } from './index.style';
+import {
+  Author,
+  AuthorDetail,
+  Wrapper,
+  ContentBox,
+  HeaderBox,
+  ParentTree,
+  ParentTreeContainer,
+  ParentFilter,
+} from './index.style';
 import ProfileImg from '../../UserProfile/ProfileImg';
 import type { Parent } from '../../../types/Post';
 import { renderMarkdown } from '../../../utils/markdown';
@@ -15,7 +24,8 @@ export default function ParentPost({ post }: { post: Parent }) {
   return (
     <Wrapper>
       <HeaderBox>
-        <Link href={`/${post.author}`}>
+        <Link href={`/post/${post._id}`}>
+          <ParentFilter />
           <Author>
             <ProfileImg imgUrl={post.authorDetail.profileimg} />
             <AuthorDetail>
@@ -30,11 +40,9 @@ export default function ParentPost({ post }: { post: Parent }) {
         <ParentTreeContainer>
           <ParentTree />
         </ParentTreeContainer>
-        <Link href={`/post/${post._id}`}>
-          <div className="content" ref={contentRef}>
-            {post.description}
-          </div>
-        </Link>
+        <div className="content" ref={contentRef}>
+          {post.description}
+        </div>
       </ContentBox>
     </Wrapper>
   );

--- a/client/components/ReadPost/index.tsx
+++ b/client/components/ReadPost/index.tsx
@@ -61,7 +61,13 @@ export default function ReadPost({ postData, title }: PostData) {
         <h1>{title}</h1>
       </TopBar>
       <PostContent>
-        {postData.parentPost ? <ParentPost post={postData.parent.at(0) as Parent} /> : <div />}
+        {postData.parentPost ? (
+          <Link href={`/post/${postData.parent.at(0)?._id}`}>
+            <ParentPost post={postData.parent.at(0) as Parent} />
+          </Link>
+        ) : (
+          <div />
+        )}
         <MainPost postData={postData} />
         <CommentBox>
           <div id="title">답글: {commentCount}개</div>

--- a/client/components/UserProfile/ProfileImg/index.tsx
+++ b/client/components/UserProfile/ProfileImg/index.tsx
@@ -21,6 +21,7 @@ export const Profile = styled.div`
   margin: 8px;
   padding-right: 45px;
   background-color: ${COLORS.WHITE};
+  z-index: 3;
   img {
     object-fit: cover;
     border-radius: 50px;

--- a/client/components/Write/Editor/index.style.ts
+++ b/client/components/Write/Editor/index.style.ts
@@ -5,11 +5,11 @@ import { buttonStyle, displayColumn, markdownStyle } from '../../../styles/mixin
 export const Wrapper = styled.div`
   height: 100%;
   min-height: 300px;
+  height: fit-content;
   flex: 1;
   background-color: white;
   display: flex;
   flex-direction: column;
-  overflow-y: scroll;
 `;
 
 export const ToolbarContainer = styled.div`

--- a/client/components/Write/Editor/index.tsx
+++ b/client/components/Write/Editor/index.tsx
@@ -426,7 +426,7 @@ export default function Editor({ parentPostData, modifyPostData }: Props) {
   const handleDrop = useCallback((e: DragEvent<HTMLDivElement>): void => {
     e.preventDefault();
     setImageOver(false);
-    handleFiles(e.dataTransfer.files);
+    if (e.dataTransfer.files.length > 0) handleFiles(e.dataTransfer.files);
   }, []);
 
   // ---------------------------------------------------------------------------------------------------------
@@ -445,11 +445,6 @@ export default function Editor({ parentPostData, modifyPostData }: Props) {
         </PostHeader>
       </CommentTopBar>
       <ToolbarContainer>
-        <EditorTabs>
-          <EditorTabTool style={{ fontWeight: 'bold' }}>B</EditorTabTool>
-          <EditorTabTool style={{ fontStyle: 'italic' }}>I</EditorTabTool>
-          <EditorTabTool style={{ textDecorationLine: 'underline' }}>U</EditorTabTool>
-        </EditorTabs>
         <EditorTabs>
           <EditorTabItem selected={tabIndex === 0} onClick={() => selectTab(0)}>
             마크다운

--- a/client/components/Write/Editor/index.tsx
+++ b/client/components/Write/Editor/index.tsx
@@ -253,6 +253,10 @@ export default function Editor({ parentPostData, modifyPostData }: Props) {
 
   const handlePaste = (e: ClipboardEvent<HTMLDivElement>) => {
     e.preventDefault();
+    if (e.clipboardData?.files.length > 0) {
+      handleFiles(e.clipboardData.files);
+      return;
+    }
     const data = e.clipboardData?.getData('Text');
     pasteAction(data);
   };

--- a/client/components/Write/Editor/index.tsx
+++ b/client/components/Write/Editor/index.tsx
@@ -122,7 +122,7 @@ export default function Editor({ parentPostData, modifyPostData }: Props) {
     if (index === 1) {
       // preview
       if (!contentRef.current) return;
-      // setContentHTML(contentRef.current.innerHTML);
+      setContentHTML(contentRef.current.innerHTML);
       setContent(contentRef.current.innerText);
       setTabIndex(1);
     }

--- a/client/components/Write/Editor/index.tsx
+++ b/client/components/Write/Editor/index.tsx
@@ -15,7 +15,6 @@ import {
   EditorContainer,
   EditorTabItem,
   EditorTabs,
-  EditorTabTool,
   EditorTextBox,
   PostHeader,
   PreviewTextBox,

--- a/client/utils/markdown/rules.ts
+++ b/client/utils/markdown/rules.ts
@@ -142,6 +142,10 @@ function hr(str: string): string {
   return result;
 }
 
+const CONATINER_BLOCKS = [blockQuote, unorderedList, orderedList];
+const LEAF_BLOCKS = [emptyLines, headers, code, divideLines, hr];
+const INLINES = [hr, bold, italic, underline, strike];
+
 export function doParse(str: string): string {
   let result = str;
   let codes: string[] = [];
@@ -151,20 +155,7 @@ export function doParse(str: string): string {
   [result, codes] = codeBlock(result);
   [result, links, imgs] = link(result);
 
-  result = pipe(
-    blockQuote,
-    unorderedList,
-    orderedList,
-    emptyLines,
-    headers,
-    code,
-    divideLines,
-    hr,
-    bold,
-    italic,
-    underline,
-    strike
-  )(result);
+  result = pipe(...CONATINER_BLOCKS, ...LEAF_BLOCKS, ...INLINES)(result);
 
   result = recoverPlaceholders(result, codes, '\u235e');
   result = recoverPlaceholders(result, links, '\u235f');

--- a/client/utils/markdown/rules.ts
+++ b/client/utils/markdown/rules.ts
@@ -1,3 +1,7 @@
+function pipe(...functions: Function[]) {
+  return (input: any) => functions.reduce((acc, fn) => fn(acc), input);
+}
+
 function emptyLines(str: string): string {
   const result = str.replace(/(?<=\n)\n/gm, '\n&nbsp;\n');
   return result;
@@ -96,14 +100,6 @@ function strike(str: string): string {
 
 // TODO : href와 src도 codeBlock처럼 따로 빼두기
 function link(str: string): [string, string[], string[]] {
-  // let result = str.replace(
-  //   /!\[(.+?)\]\(((?:https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}(\.[a-zA-Z0-9()]{1,6})?\b(?:[-a-zA-Z0-9()@:%_+.~#?&//=]*)))\)/gm,
-  //   '<img src="$2" alt="$1"/>'
-  // );
-  // result = result.replace(
-  //   /\[(.+?)\]\(((?:https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}(\.[a-zA-Z0-9()]{1,6})?\b(?:[-a-zA-Z0-9()@:%_+.~#?&//=]*)))\)/gm,
-  //   '<a href="$2">$1</a>'
-  // );
   let result = str.replace(
     /!\[(.+?)\]\(((?:https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}(\.[a-zA-Z0-9()]{1,6})?\b(?:[-a-zA-Z0-9()@:%_+.~#?&//=]*)))\)/gm,
     '\u235f'
@@ -147,31 +143,33 @@ function hr(str: string): string {
 }
 
 export function doParse(str: string): string {
-  // console.log('parse start');
-  // console.log(JSON.stringify(result));
   let result = str;
   let codes: string[] = [];
   let links: string[] = [];
   let imgs: string[] = [];
+
   [result, codes] = codeBlock(result);
   [result, links, imgs] = link(result);
-  result = blockQuote(result);
-  result = emptyLines(result);
-  result = headers(result);
-  result = code(result);
-  result = unorderedList(result);
-  result = orderedList(result);
-  result = divideLines(result);
-  result = hr(result);
-  result = bold(result);
-  result = italic(result);
-  result = underline(result);
-  result = strike(result);
+
+  result = pipe(
+    blockQuote,
+    unorderedList,
+    orderedList,
+    emptyLines,
+    headers,
+    code,
+    divideLines,
+    hr,
+    bold,
+    italic,
+    underline,
+    strike
+  )(result);
+
   result = recoverPlaceholders(result, codes, '\u235e');
   result = recoverPlaceholders(result, links, '\u235f');
   result = recoverPlaceholders(result, imgs, '\u2360');
-  // console.log(JSON.stringify(result));
-  // console.log(codes);
+
   return result;
 }
 


### PR DESCRIPTION
아래와 같은 수정내역을 포함합니다.
- Parentpost가 존재하는 게시글의 Parentpost 표시 영역을 제한하였습니다.
- 에디터에서 텍스트를 드래그 앤 드롭 시 발생하는 오류를 수정하였습니다.
- 이제 이미지를 붙여넣기 하는 것으로 에디터에 그림을 삽입할 수 있습니다.
- 마크다운 파서 구조를 정리했습니다.
- 게시글 수정 화면에서 미리보기 탭에 갔다가 다시 에디터로 돌아오면 내용이 초기화되는 문제를 수정하였습니다.